### PR TITLE
fix: remove silent try-catch in StartSessionMiddleware::after()

### DIFF
--- a/WebFiori/Framework/Middleware/StartSessionMiddleware.php
+++ b/WebFiori/Framework/Middleware/StartSessionMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace WebFiori\Framework\Middleware;
 
-use Error;
 use WebFiori\Framework\Session\SessionsManager;
 use WebFiori\Http\Request;
 use WebFiori\Http\Response;
@@ -22,13 +21,10 @@ class StartSessionMiddleware extends AbstractMiddleware {
         $this->addToGroup('web');
     }
     public function after(Request $request, Response $response) {
-        try {
-            $sessionsCookiesHeaders = SessionsManager::getCookiesHeaders();
+        $sessionsCookiesHeaders = SessionsManager::getCookiesHeaders();
 
-            foreach ($sessionsCookiesHeaders as $headerVal) {
-                $response->addHeader('set-cookie', $headerVal);
-            }
-        } catch (Error $exc) {
+        foreach ($sessionsCookiesHeaders as $headerVal) {
+            $response->addHeader('set-cookie', $headerVal);
         }
     }
 


### PR DESCRIPTION
# Summary
Remove the empty `catch (Error $exc)` block in `StartSessionMiddleware::after()` that silently swallowed all errors, including the static call bug from #297.

## Motivation
The empty catch block made bugs invisible — no logging, no propagation. The static call to `Response::addHeader()` (fixed in #297) was hidden by this for the entire lifetime of the middleware. Errors in middleware should propagate so they can be diagnosed. Fixes #298.

## Changes
- Removed `try/catch (Error $exc)` wrapper from `StartSessionMiddleware::after()`
- Removed unused `use Error` import

## How to Test / Verify
- Any error in `after()` will now propagate instead of being silently ignored
- Existing test suite passes (672 tests, all non-DB tests green)

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #298