### PR TITLE
Add migrations:skip command and --all-connections support

### DIFF
--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -377,6 +377,7 @@ class App {
                     '\\WebFiori\\Framework\\Cli\\Commands\\DryRunMigrationsCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\MigrationsStatusCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\FreshMigrationsCommand',
+                    '\\WebFiori\\Framework\\Cli\\Commands\\SkipMigrationsCommand',
                 ];
 
                 foreach ($commands as $c) {

--- a/WebFiori/Framework/Cli/Commands/RunMigrationsCommandNew.php
+++ b/WebFiori/Framework/Cli/Commands/RunMigrationsCommandNew.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is licensed under MIT License.
  *
@@ -20,30 +21,41 @@ use WebFiori\Framework\Cli\CLIUtils;
 
 /**
  * Command for executing database migrations.
- * 
+ *
  * @author Ibrahim
  */
 class RunMigrationsCommandNew extends Command {
-    
     private ?SchemaRunner $runner = null;
-    
+
     public function __construct() {
         parent::__construct('migrations:run', [
             new Argument('--connection', 'The name of database connection to use.', true),
             new Argument('--env', 'Environment name (dev, staging, production). Default: dev', true),
+            new Argument('--all-connections', 'Run migrations against all registered connections.', true),
         ], 'Execute pending database migrations.');
     }
-    
+
     public function exec(): int {
+        if ($this->isArgProvided('--all-connections') && $this->isArgProvided('--connection')) {
+            $this->error('Cannot use --all-connections and --connection together.');
+
+            return 1;
+        }
+
+        if ($this->isArgProvided('--all-connections')) {
+            return $this->runAllConnections();
+        }
+
         try {
             $connection = $this->getConnection();
+
             if ($connection === null) {
                 return 1;
             }
-            
+
             $env = $this->getArgValue('--env') ?? 'dev';
             $this->runner = new SchemaRunner($connection, $env);
-            
+
             // Discover migrations
             $migrationsPath = APP_PATH.'Database'.DS.'Migrations';
             $namespace = APP_DIR.'\\Database\\Migrations';
@@ -52,24 +64,29 @@ class RunMigrationsCommandNew extends Command {
             $seedersPath = APP_PATH.'Database'.DS.'Seeders';
             $seedersNamespace = APP_DIR.'\\Database\\Seeders';
             $count += $this->runner->discoverFromPath($seedersPath, $seedersNamespace, true);
-            
+
             if ($count === 0) {
                 $this->info('No migrations found.');
+
                 return 0;
             }
-            
+
+            $this->validateTargetConnections($this->runner, App::getConfig()->getDBConnections());
+
             return $this->runMigrations();
-            
         } catch (Throwable $e) {
             $msg = $e->getMessage();
+
             if ((str_contains($msg, ".schema_changes' doesn't exist") && $e->getCode() == 1146)) {
                 $this->warning('Table "schema_changes" does not exist. No migrations executed.');
                 $this->info('Run "migrations:ini" to create the table.');
+
                 return 1;
             }
             $this->error('An exception was thrown.');
-            $this->println('Message: ' . $e->getMessage());
-            $this->println('File: ' . $e->getFile() . ':' . $e->getLine());
+            $this->println('Message: '.$e->getMessage());
+            $this->println('File: '.$e->getFile().':'.$e->getLine());
+
             return 1;
         } finally {
             if ($this->runner !== null) {
@@ -77,73 +94,170 @@ class RunMigrationsCommandNew extends Command {
             }
         }
     }
-    
+
     private function getConnection(): ?ConnectionInfo {
         $connections = App::getConfig()->getDBConnections();
-        
+
         if (empty($connections)) {
             $this->info('No database connections configured.');
+
             return null;
         }
-        
+
         $connectionName = $this->getArgValue('--connection');
-        
+
         if ($connectionName !== null) {
             $connection = App::getConfig()->getDBConnection($connectionName);
+
             if ($connection === null) {
                 $this->error("Connection '$connectionName' not found.");
+
                 return null;
             }
+
             return $connection;
         }
-        
+
         return CLIUtils::getConnectionName($this);
     }
-    
+
+    private function runAllConnections(): int {
+        $connections = App::getConfig()->getDBConnections();
+
+        if (empty($connections)) {
+            $this->info('No database connections configured.');
+
+            return 0;
+        }
+
+        $env = $this->getArgValue('--env') ?? 'dev';
+        $hasFailure = false;
+
+        foreach ($connections as $name => $connection) {
+            $this->println('');
+            $this->println('=== Connection: '.$name.' ===');
+
+            try {
+                $runner = new SchemaRunner($connection, $env);
+
+                $migrationsPath = APP_PATH.'Database'.DS.'Migrations';
+                $namespace = APP_DIR.'\\Database\\Migrations';
+                $count = $runner->discoverFromPath($migrationsPath, $namespace, true);
+
+                $seedersPath = APP_PATH.'Database'.DS.'Seeders';
+                $seedersNamespace = APP_DIR.'\\Database\\Seeders';
+                $count += $runner->discoverFromPath($seedersPath, $seedersNamespace, true);
+
+                if ($count === 0) {
+                    $this->info('No migrations found.');
+                    $runner->close();
+                    continue;
+                }
+
+                $this->validateTargetConnections($runner, $connections);
+
+                $runner->createSchemaTable();
+                $result = $runner->apply();
+
+                foreach ($result->getApplied() as $change) {
+                    $this->success('Applied: '.$change->getName());
+                }
+
+                foreach ($result->getSkipped() as $item) {
+                    $this->warning('Skipped: '.$item['change']->getName().' ('.$item['reason'].')');
+                }
+
+                foreach ($result->getFailed() as $item) {
+                    $this->error('Failed: '.$item['change']->getName());
+                    $this->println('  Error: '.$item['error']->getMessage());
+                    $hasFailure = true;
+                }
+
+                $applied = count($result->getApplied());
+                $this->info("Applied: $applied change(s). Time: ".round($result->getTotalTime(), 2).'ms');
+
+                $runner->close();
+            } catch (Throwable $e) {
+                $this->error('Error on connection '.$name.': '.$e->getMessage());
+                $hasFailure = true;
+            }
+        }
+
+        return $hasFailure ? 1 : 0;
+    }
+
     private function runMigrations(): int {
         $this->println('Running migrations...');
-        
+
         $result = $this->runner->apply();
-        
+
         $applied = $result->getApplied();
+
         if (!empty($applied)) {
             foreach ($applied as $change) {
-                $this->success('Applied: ' . $change->getName());
+                $this->success('Applied: '.$change->getName());
             }
         }
-        
+
         $skipped = $result->getSkipped();
+
         if (!empty($skipped)) {
             foreach ($skipped as $item) {
-                $this->warning('Skipped: ' . $item['change']->getName() . ' (' . $item['reason'] . ')');
+                $this->warning('Skipped: '.$item['change']->getName().' ('.$item['reason'].')');
             }
         }
-        
+
         $failed = $result->getFailed();
+
         if (!empty($failed)) {
             foreach ($failed as $item) {
-                $this->error('Failed: ' . $item['change']->getName());
-                $this->println('  Error: ' . $item['error']->getMessage());
+                $this->error('Failed: '.$item['change']->getName());
+                $this->println('  Error: '.$item['error']->getMessage());
             }
         }
-        
+
         $migrationsCount = count(array_filter($result->getApplied(), fn($c) => $c->getType() === 'migration'));
         $seedersCount = count(array_filter($result->getApplied(), fn($c) => $c->getType() === 'seeder'));
 
         if ($migrationsCount > 0) {
-            $this->info('Applied: ' . $migrationsCount . ' migration(s)');
+            $this->info('Applied: '.$migrationsCount.' migration(s)');
         }
 
         if ($seedersCount > 0) {
-            $this->info('Applied: ' . $seedersCount . ' seeder(s)');
+            $this->info('Applied: '.$seedersCount.' seeder(s)');
         }
 
         if ($migrationsCount === 0 && $seedersCount === 0) {
             $this->info('Applied: 0 migrations');
         }
 
-        $this->info('Time: ' . round($result->getTotalTime(), 2) . 'ms');
-        
+        $this->info('Time: '.round($result->getTotalTime(), 2).'ms');
+
         return !empty($failed) ? 1 : 0;
+    }
+
+    private function validateTargetConnections(SchemaRunner $runner, array $registeredConnections): void {
+        $registeredNames = array_keys($registeredConnections);
+        $currentName = $runner->getConnectionInfo()->getName();
+
+        $hasTargeted = false;
+
+        foreach ($runner->getChanges() as $change) {
+            $targets = $change->getTargetConnections();
+
+            if (!empty($targets)) {
+                $hasTargeted = true;
+
+                foreach ($targets as $target) {
+                    if (!in_array($target, $registeredNames)) {
+                        $this->warning('Migration '.$change->getName().' targets unknown connection: '.$target);
+                    }
+                }
+            }
+        }
+
+        if ($hasTargeted && $currentName === 'New_Connection') {
+            $this->warning('Connection has default name "New_Connection". Connection-targeted migrations may not filter correctly. Set a name via ConnectionInfo::setName().');
+        }
     }
 }

--- a/WebFiori/Framework/Cli/Commands/SkipMigrationsCommand.php
+++ b/WebFiori/Framework/Cli/Commands/SkipMigrationsCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is licensed under MIT License.
  *
@@ -20,13 +21,12 @@ use WebFiori\Framework\Cli\CLIUtils;
 
 /**
  * Command for skipping (baselining) database migrations without executing them.
- * 
+ *
  * @author Ibrahim
  */
 class SkipMigrationsCommand extends Command {
-    
     private ?SchemaRunner $runner = null;
-    
+
     public function __construct() {
         parent::__construct('migrations:skip', [
             new Argument('--connection', 'The name of database connection to use.', true),
@@ -36,17 +36,18 @@ class SkipMigrationsCommand extends Command {
             new Argument('--up-to', 'Skip all migrations up to and including the named one.', true),
         ], 'Mark migrations as applied without executing them (baseline).');
     }
-    
+
     public function exec(): int {
         try {
             $connection = $this->getConnection();
+
             if ($connection === null) {
                 return 1;
             }
-            
+
             $env = $this->getArgValue('--env') ?? 'dev';
             $this->runner = new SchemaRunner($connection, $env);
-            
+
             // Discover migrations
             $migrationsPath = APP_PATH.'Database'.DS.'Migrations';
             $namespace = APP_DIR.'\\Database\\Migrations';
@@ -55,24 +56,27 @@ class SkipMigrationsCommand extends Command {
             $seedersPath = APP_PATH.'Database'.DS.'Seeders';
             $seedersNamespace = APP_DIR.'\\Database\\Seeders';
             $count += $this->runner->discoverFromPath($seedersPath, $seedersNamespace, true);
-            
+
             if ($count === 0) {
                 $this->info('No migrations found.');
+
                 return 0;
             }
-            
+
             return $this->skip();
-            
         } catch (Throwable $e) {
             $msg = $e->getMessage();
+
             if (str_contains($msg, ".schema_changes' doesn't exist") && $e->getCode() == 1146) {
                 $this->warning('Table "schema_changes" does not exist.');
                 $this->info('Run "migrations:ini" to create the table.');
+
                 return 1;
             }
             $this->error('An exception was thrown.');
-            $this->println('Message: ' . $e->getMessage());
-            $this->println('File: ' . $e->getFile() . ':' . $e->getLine());
+            $this->println('Message: '.$e->getMessage());
+            $this->println('File: '.$e->getFile().':'.$e->getLine());
+
             return 1;
         } finally {
             if ($this->runner !== null) {
@@ -80,29 +84,33 @@ class SkipMigrationsCommand extends Command {
             }
         }
     }
-    
+
     private function getConnection(): ?ConnectionInfo {
         $connections = App::getConfig()->getDBConnections();
-        
+
         if (empty($connections)) {
             $this->info('No database connections configured.');
+
             return null;
         }
-        
+
         $connectionName = $this->getArgValue('--connection');
-        
+
         if ($connectionName !== null) {
             $connection = App::getConfig()->getDBConnection($connectionName);
+
             if ($connection === null) {
                 $this->error("Connection '$connectionName' not found.");
+
                 return null;
             }
+
             return $connection;
         }
-        
+
         return CLIUtils::getConnectionName($this);
     }
-    
+
     private function skip(): int {
         if ($this->isArgProvided('--all')) {
             return $this->skipAll();
@@ -111,54 +119,59 @@ class SkipMigrationsCommand extends Command {
         } else if ($this->isArgProvided('--up-to')) {
             return $this->skipUpTo();
         }
-        
+
         $this->error('Provide --name, --all, or --up-to.');
+
         return 1;
     }
-    
+
     private function skipAll(): int {
         $skipped = $this->runner->skipAll();
-        
+
         if (empty($skipped)) {
             $this->info('No pending migrations to skip.');
+
             return 0;
         }
-        
+
         foreach ($skipped as $change) {
-            $this->success('Skipped: ' . $change->getName());
+            $this->success('Skipped: '.$change->getName());
         }
-        $this->info('Total skipped: ' . count($skipped));
-        
+        $this->info('Total skipped: '.count($skipped));
+
         return 0;
     }
-    
+
     private function skipSingle(): int {
         $name = $this->getArgValue('--name');
         $result = $this->runner->skip($name);
-        
+
         if ($result) {
-            $this->success('Skipped: ' . $name);
+            $this->success('Skipped: '.$name);
+
             return 0;
         }
-        
-        $this->warning('Could not skip: ' . $name . ' (not found or already applied)');
+
+        $this->warning('Could not skip: '.$name.' (not found or already applied)');
+
         return 1;
     }
-    
+
     private function skipUpTo(): int {
         $name = $this->getArgValue('--up-to');
         $skipped = $this->runner->skipUpTo($name);
-        
+
         if (empty($skipped)) {
             $this->info('No pending migrations to skip.');
+
             return 0;
         }
-        
+
         foreach ($skipped as $change) {
-            $this->success('Skipped: ' . $change->getName());
+            $this->success('Skipped: '.$change->getName());
         }
-        $this->info('Total skipped: ' . count($skipped));
-        
+        $this->info('Total skipped: '.count($skipped));
+
         return 0;
     }
 }

--- a/WebFiori/Framework/Cli/Commands/SkipMigrationsCommand.php
+++ b/WebFiori/Framework/Cli/Commands/SkipMigrationsCommand.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026-present WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Framework\Cli\Commands;
+
+use Throwable;
+use WebFiori\Cli\Argument;
+use WebFiori\Cli\Command;
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Database\Schema\SchemaRunner;
+use WebFiori\Framework\App;
+use WebFiori\Framework\Cli\CLIUtils;
+
+/**
+ * Command for skipping (baselining) database migrations without executing them.
+ * 
+ * @author Ibrahim
+ */
+class SkipMigrationsCommand extends Command {
+    
+    private ?SchemaRunner $runner = null;
+    
+    public function __construct() {
+        parent::__construct('migrations:skip', [
+            new Argument('--connection', 'The name of database connection to use.', true),
+            new Argument('--env', 'Environment name (dev, staging, production). Default: dev', true),
+            new Argument('--name', 'Fully qualified class name of a single migration to skip.', true),
+            new Argument('--all', 'Skip all pending migrations.', true),
+            new Argument('--up-to', 'Skip all migrations up to and including the named one.', true),
+        ], 'Mark migrations as applied without executing them (baseline).');
+    }
+    
+    public function exec(): int {
+        try {
+            $connection = $this->getConnection();
+            if ($connection === null) {
+                return 1;
+            }
+            
+            $env = $this->getArgValue('--env') ?? 'dev';
+            $this->runner = new SchemaRunner($connection, $env);
+            
+            // Discover migrations
+            $migrationsPath = APP_PATH.'Database'.DS.'Migrations';
+            $namespace = APP_DIR.'\\Database\\Migrations';
+            $count = $this->runner->discoverFromPath($migrationsPath, $namespace, true);
+
+            $seedersPath = APP_PATH.'Database'.DS.'Seeders';
+            $seedersNamespace = APP_DIR.'\\Database\\Seeders';
+            $count += $this->runner->discoverFromPath($seedersPath, $seedersNamespace, true);
+            
+            if ($count === 0) {
+                $this->info('No migrations found.');
+                return 0;
+            }
+            
+            return $this->skip();
+            
+        } catch (Throwable $e) {
+            $msg = $e->getMessage();
+            if (str_contains($msg, ".schema_changes' doesn't exist") && $e->getCode() == 1146) {
+                $this->warning('Table "schema_changes" does not exist.');
+                $this->info('Run "migrations:ini" to create the table.');
+                return 1;
+            }
+            $this->error('An exception was thrown.');
+            $this->println('Message: ' . $e->getMessage());
+            $this->println('File: ' . $e->getFile() . ':' . $e->getLine());
+            return 1;
+        } finally {
+            if ($this->runner !== null) {
+                $this->runner->close();
+            }
+        }
+    }
+    
+    private function getConnection(): ?ConnectionInfo {
+        $connections = App::getConfig()->getDBConnections();
+        
+        if (empty($connections)) {
+            $this->info('No database connections configured.');
+            return null;
+        }
+        
+        $connectionName = $this->getArgValue('--connection');
+        
+        if ($connectionName !== null) {
+            $connection = App::getConfig()->getDBConnection($connectionName);
+            if ($connection === null) {
+                $this->error("Connection '$connectionName' not found.");
+                return null;
+            }
+            return $connection;
+        }
+        
+        return CLIUtils::getConnectionName($this);
+    }
+    
+    private function skip(): int {
+        if ($this->isArgProvided('--all')) {
+            return $this->skipAll();
+        } else if ($this->isArgProvided('--name')) {
+            return $this->skipSingle();
+        } else if ($this->isArgProvided('--up-to')) {
+            return $this->skipUpTo();
+        }
+        
+        $this->error('Provide --name, --all, or --up-to.');
+        return 1;
+    }
+    
+    private function skipAll(): int {
+        $skipped = $this->runner->skipAll();
+        
+        if (empty($skipped)) {
+            $this->info('No pending migrations to skip.');
+            return 0;
+        }
+        
+        foreach ($skipped as $change) {
+            $this->success('Skipped: ' . $change->getName());
+        }
+        $this->info('Total skipped: ' . count($skipped));
+        
+        return 0;
+    }
+    
+    private function skipSingle(): int {
+        $name = $this->getArgValue('--name');
+        $result = $this->runner->skip($name);
+        
+        if ($result) {
+            $this->success('Skipped: ' . $name);
+            return 0;
+        }
+        
+        $this->warning('Could not skip: ' . $name . ' (not found or already applied)');
+        return 1;
+    }
+    
+    private function skipUpTo(): int {
+        $name = $this->getArgValue('--up-to');
+        $skipped = $this->runner->skipUpTo($name);
+        
+        if (empty($skipped)) {
+            $this->info('No pending migrations to skip.');
+            return 0;
+        }
+        
+        foreach ($skipped as $change) {
+            $this->success('Skipped: ' . $change->getName());
+        }
+        $this->info('Total skipped: ' . count($skipped));
+        
+        return 0;
+    }
+}

--- a/WebFiori/Framework/Config/JsonDriver.php
+++ b/WebFiori/Framework/Config/JsonDriver.php
@@ -234,6 +234,7 @@ class JsonDriver implements ConfigurationDriver {
             } else if (gettype($extras) == 'array') {
                 $extrasArr = $extras;
             }
+            $extrasArr['connection-name'] = trim($conName);
 
             return new ConnectionInfo(
                 $this->getProp($jsonObj, 'type', $conName),

--- a/tests/WebFiori/Framework/Tests/Cli/ConnectionTargetedMigrationsTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/ConnectionTargetedMigrationsTest.php
@@ -1,0 +1,326 @@
+<?php
+namespace WebFiori\Framework\Test\Cli;
+
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Framework\App;
+use WebFiori\Framework\Cli\CLITestCase;
+use WebFiori\Framework\Cli\Commands\InitMigrationsCommand;
+use WebFiori\Framework\Cli\Commands\RunMigrationsCommandNew;
+
+/**
+ * Test cases for connection-targeted migrations CLI support.
+ */
+class ConnectionTargetedMigrationsTest extends CLITestCase {
+    private ConnectionInfo $mssqlConnection;
+    private ConnectionInfo $mysqlConnection;
+
+    /**
+     * @test
+     */
+    public function testAllConnectionsAndConnectionMutuallyExclusive() {
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--all-connections' => '',
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Cannot use --all-connections and --connection together', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testAllConnectionsMixedTargeting() {
+        // Create migrations: one for mysql, one for mssql (simulated as second mysql conn), one for all
+        $this->createTargetedMigration('MysqlOnly', "['mysql-db']");
+        $this->createTargetedMigration('SecondOnly', "['second-db']");
+        $this->createTargetedMigration('Universal', '[]');
+
+        // Add a second mysql connection with different name (same physical DB for testing)
+        $secondConn = new ConnectionInfo('mysql', 'root', MYSQL_ROOT_PASSWORD, 'testing_db', '127.0.0.1', 3306);
+        $secondConn->setName('second-db');
+        App::getConfig()->addOrUpdateDBConnection($secondConn);
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--all-connections' => ''
+        ]);
+
+        $outputStr = implode('', $output);
+
+        // mysql-db section should apply MysqlOnly + Universal, skip SecondOnly
+        $this->assertStringContainsString('=== Connection: mysql-db ===', $outputStr);
+        $this->assertStringContainsString('=== Connection: second-db ===', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testAllConnectionsNoConnections() {
+        App::getConfig()->removeAllDBConnections();
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--all-connections' => ''
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('No database connections configured', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testAllConnectionsRunsOnBoth() {
+        $this->createTargetedMigration('ForMysql', "['mysql-db']");
+        $this->createTargetedMigration('ForAll', '[]');
+
+        $this->initMigrationsFor('mysql-db');
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--all-connections' => ''
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('=== Connection: mysql-db ===', $outputStr);
+        $this->assertStringContainsString('Applied: App\\Database\\Migrations\\ForAll', $outputStr);
+        $this->assertStringContainsString('Applied: App\\Database\\Migrations\\ForMysql', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test - Integration: targeted migration on MSSQL connection
+     */
+    public function testMssqlTargetedMigration() {
+        try {
+            $this->setupMssqlConnection();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('MSSQL connection not available: '.$e->getMessage());
+
+            return;
+        }
+
+        $this->createTargetedMigration('MssqlMig', "['mssql-db']");
+
+        // Run against mysql - should skip
+        $this->initMigrationsFor('mysql-db');
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\MssqlMig', $outputStr);
+
+        // Run against mssql - should apply
+        $this->initMigrationsFor('mssql-db');
+        $output2 = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mssql-db'
+        ]);
+
+        $outputStr2 = implode('', $output2);
+        $this->assertStringContainsString('Applied: App\\Database\\Migrations\\MssqlMig', $outputStr2);
+    }
+
+    /**
+     * @test
+     */
+    public function testMultiTargetMigrationRunsOnEither() {
+        $this->createTargetedMigration('MultiTarget', "['mysql-db', 'mssql-db']");
+        $this->initMigrationsFor('mysql-db');
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Applied: App\\Database\\Migrations\\MultiTarget', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testTargetedMigrationRunsOnCorrectConnection() {
+        $this->createTargetedMigration('OnlyMysql', "['mysql-db']");
+        $this->initMigrationsFor('mysql-db');
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Applied: App\\Database\\Migrations\\OnlyMysql', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testTargetedMigrationSkippedOnWrongConnection() {
+        $this->createTargetedMigration('OnlyMssql', "['mssql-db']");
+        $this->initMigrationsFor('mysql-db');
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\OnlyMssql', $outputStr);
+        $this->assertStringContainsString('Connection mismatch', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testValidationWarnsDefaultConnectionName() {
+        // Add a connection with default name
+        $defaultConn = new ConnectionInfo('mysql', 'root', MYSQL_ROOT_PASSWORD, 'testing_db', '127.0.0.1', 3306);
+        // Don't set name — it stays as 'New_Connection'
+        App::getConfig()->addOrUpdateDBConnection($defaultConn);
+
+        $this->createTargetedMigration('SomeTargeted', "['mysql-db']");
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'New_Connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('default name "New_Connection"', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testValidationWarnsUnknownTargetConnection() {
+        $this->createTargetedMigration('BadTarget', "['nonexistent-db']");
+        $this->initMigrationsFor('mysql-db');
+
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'mysql-db'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('targets unknown connection: nonexistent-db', $outputStr);
+    }
+
+    private function cleanupMigrations(): void {
+        $dir = APP_PATH.'Database'.DS.'Migrations';
+
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isFile() && $item->getExtension() === 'php') {
+                unlink($item->getRealPath());
+            }
+        }
+    }
+
+    // --- Helpers ---
+
+    private function createTargetedMigration(string $name, string $targets): void {
+        $dir = APP_PATH.'Database'.DS.'Migrations';
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = <<<PHP
+<?php
+namespace App\Database\Migrations;
+
+use WebFiori\Database\Database;
+use WebFiori\Database\Schema\AbstractMigration;
+
+class $name extends AbstractMigration {
+    public function getTargetConnections(): array {
+        return $targets;
+    }
+
+    public function up(Database \$db): void {
+        // Test migration - no-op
+    }
+    
+    public function down(Database \$db): void {
+    }
+}
+PHP;
+
+        file_put_contents($dir.DS.$name.'.php', $content);
+    }
+
+    private function dropSchemaTable(string $connectionName = 'mysql-db'): void {
+        try {
+            $conn = App::getConfig()->getDBConnection($connectionName);
+
+            if ($conn !== null) {
+                $db = new \WebFiori\Database\Database($conn);
+                $db->raw("DROP TABLE IF EXISTS schema_changes")->execute();
+                $db->close();
+            }
+        } catch (\Throwable $e) {
+            // Ignore
+        }
+    }
+
+    private function initMigrationsFor(string $connectionName): void {
+        $this->executeMultiCommand([
+            InitMigrationsCommand::class,
+            '--connection' => $connectionName
+        ]);
+    }
+
+    private function setupMssqlConnection(): void {
+        $password = getenv('SA_SQL_SERVER_PASSWORD') ?: '1234567890@Eu';
+        $this->mssqlConnection = new ConnectionInfo('mssql', 'sa', $password, 'testing_db', 'localhost', 1433, [
+            'TrustServerCertificate' => 'true'
+        ]);
+        $this->mssqlConnection->setName('mssql-db');
+        App::getConfig()->addOrUpdateDBConnection($this->mssqlConnection);
+
+        // Test connection works
+        $db = new \WebFiori\Database\Database($this->mssqlConnection);
+        $db->raw("SELECT 1 AS test")->execute();
+        $db->close();
+    }
+
+    private function setupMysqlConnection(): void {
+        $this->mysqlConnection = new ConnectionInfo('mysql', 'root', MYSQL_ROOT_PASSWORD, 'testing_db', '127.0.0.1', 3306);
+        $this->mysqlConnection->setName('mysql-db');
+        App::getConfig()->addOrUpdateDBConnection($this->mysqlConnection);
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+        App::getConfig()->removeAllDBConnections();
+        $this->setupMysqlConnection();
+        $this->dropSchemaTable('mysql-db');
+        $this->cleanupMigrations();
+    }
+
+    protected function tearDown(): void {
+        $this->cleanupMigrations();
+        $this->dropSchemaTable('mysql-db');
+        $this->dropSchemaTable('mssql-db');
+        parent::tearDown();
+    }
+}

--- a/tests/WebFiori/Framework/Tests/Cli/HelpCommandTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/HelpCommandTest.php
@@ -46,6 +46,7 @@ class HelpCommandTest extends CLITestCase {
             "    migrations:dry-run:      Preview pending migrations without executing.\n",
             "    migrations:status:       Show migration status (applied and pending).\n",
             "    migrations:fresh:        Rollback all migrations and run them fresh.\n",
+            "    migrations:skip:         Mark migrations as applied without executing them (baseline).\n",
         ], $this->executeMultiCommand([
             'help',
         ]));

--- a/tests/WebFiori/Framework/Tests/Cli/SkipMigrationsCommandTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/SkipMigrationsCommandTest.php
@@ -4,81 +4,15 @@ namespace WebFiori\Framework\Test\Cli;
 use WebFiori\Database\ConnectionInfo;
 use WebFiori\Framework\App;
 use WebFiori\Framework\Cli\CLITestCase;
-use WebFiori\Framework\Cli\Commands\SkipMigrationsCommand;
-use WebFiori\Framework\Cli\Commands\RunMigrationsCommandNew;
 use WebFiori\Framework\Cli\Commands\InitMigrationsCommand;
+use WebFiori\Framework\Cli\Commands\RunMigrationsCommandNew;
+use WebFiori\Framework\Cli\Commands\SkipMigrationsCommand;
 
 /**
  * Test cases for SkipMigrationsCommand.
  */
 class SkipMigrationsCommandTest extends CLITestCase {
     private ConnectionInfo $testConnection;
-
-    /**
-     * @test
-     */
-    public function testSkipWithNoConnections() {
-        App::getConfig()->removeAllDBConnections();
-
-        $output = $this->executeMultiCommand([
-            SkipMigrationsCommand::class,
-            '--all' => ''
-        ]);
-
-        $this->assertEquals([
-            "Info: No database connections configured.\n"
-        ], $output);
-        $this->assertEquals(1, $this->getExitCode());
-    }
-
-    /**
-     * @test
-     */
-    public function testSkipWithInvalidConnection() {
-        $output = $this->executeMultiCommand([
-            SkipMigrationsCommand::class,
-            '--all' => '',
-            '--connection' => 'ghost'
-        ]);
-
-        $this->assertEquals([
-            "Error: Connection 'ghost' not found.\n"
-        ], $output);
-        $this->assertEquals(1, $this->getExitCode());
-    }
-
-    /**
-     * @test
-     */
-    public function testSkipWithNoMigrations() {
-        $output = $this->executeMultiCommand([
-            SkipMigrationsCommand::class,
-            '--all' => '',
-            '--connection' => 'test-connection'
-        ]);
-
-        $this->assertEquals([
-            "Info: No migrations found.\n"
-        ], $output);
-        $this->assertEquals(0, $this->getExitCode());
-    }
-
-    /**
-     * @test
-     */
-    public function testSkipWithNoModeFlag() {
-        $this->createTestMigration('NoMode1');
-        $this->initMigrations();
-
-        $output = $this->executeMultiCommand([
-            SkipMigrationsCommand::class,
-            '--connection' => 'test-connection'
-        ]);
-
-        $outputStr = implode('', $output);
-        $this->assertStringContainsString('Provide --name, --all, or --up-to', $outputStr);
-        $this->assertEquals(1, $this->getExitCode());
-    }
 
     /**
      * @test
@@ -99,6 +33,102 @@ class SkipMigrationsCommandTest extends CLITestCase {
         $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\SkipAll2', $outputStr);
         $this->assertStringContainsString('Total skipped: 2', $outputStr);
         $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipAllWhenNothingPending() {
+        $this->createTestMigration('NoPending');
+        $this->initMigrations();
+
+        // Run it first
+        $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        // Skip all - nothing left
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('No pending migrations to skip', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipAlreadyApplied() {
+        $this->createTestMigration('AlreadyDone');
+        $this->initMigrations();
+
+        // Run it first
+        $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        // Try to skip it
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--name' => 'App\\Database\\Migrations\\AlreadyDone',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Could not skip', $outputStr);
+        $this->assertStringContainsString('not found or already applied', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkippedMigrationWontRun() {
+        $this->createTestMigration('WontRun');
+        $this->initMigrations();
+
+        // Skip it
+        $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--name' => 'App\\Database\\Migrations\\WontRun',
+            '--connection' => 'test-connection'
+        ]);
+
+        // Now run migrations
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\WontRun', $outputStr);
+        $this->assertStringNotContainsString('Applied: App\\Database\\Migrations\\WontRun', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipSchemaTableMissing() {
+        $this->createTestMigration('NoTable');
+        // Do NOT call initMigrations()
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('schema_changes', $outputStr);
+        $this->assertStringContainsString('migrations:ini', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
     }
 
     /**
@@ -142,112 +172,96 @@ class SkipMigrationsCommandTest extends CLITestCase {
     /**
      * @test
      */
-    public function testSkipAlreadyApplied() {
-        $this->createTestMigration('AlreadyDone');
-        $this->initMigrations();
-
-        // Run it first
-        $this->executeMultiCommand([
-            RunMigrationsCommandNew::class,
-            '--connection' => 'test-connection'
-        ]);
-
-        // Try to skip it
+    public function testSkipWithInvalidConnection() {
         $output = $this->executeMultiCommand([
             SkipMigrationsCommand::class,
-            '--name' => 'App\\Database\\Migrations\\AlreadyDone',
-            '--connection' => 'test-connection'
+            '--all' => '',
+            '--connection' => 'ghost'
         ]);
 
-        $outputStr = implode('', $output);
-        $this->assertStringContainsString('Could not skip', $outputStr);
-        $this->assertStringContainsString('not found or already applied', $outputStr);
+        $this->assertEquals([
+            "Error: Connection 'ghost' not found.\n"
+        ], $output);
         $this->assertEquals(1, $this->getExitCode());
     }
 
     /**
      * @test
      */
-    public function testSkipAllWhenNothingPending() {
-        $this->createTestMigration('NoPending');
-        $this->initMigrations();
-
-        // Run it first
-        $this->executeMultiCommand([
-            RunMigrationsCommandNew::class,
-            '--connection' => 'test-connection'
-        ]);
-
-        // Skip all - nothing left
-        $output = $this->executeMultiCommand([
-            SkipMigrationsCommand::class,
-            '--all' => '',
-            '--connection' => 'test-connection'
-        ]);
-
-        $outputStr = implode('', $output);
-        $this->assertStringContainsString('No pending migrations to skip', $outputStr);
-        $this->assertEquals(0, $this->getExitCode());
-    }
-
-    /**
-     * @test
-     */
-    public function testSkipSchemaTableMissing() {
-        $this->createTestMigration('NoTable');
-        // Do NOT call initMigrations()
+    public function testSkipWithNoConnections() {
+        App::getConfig()->removeAllDBConnections();
 
         $output = $this->executeMultiCommand([
             SkipMigrationsCommand::class,
-            '--all' => '',
-            '--connection' => 'test-connection'
+            '--all' => ''
         ]);
 
-        $outputStr = implode('', $output);
-        $this->assertStringContainsString('schema_changes', $outputStr);
-        $this->assertStringContainsString('migrations:ini', $outputStr);
+        $this->assertEquals([
+            "Info: No database connections configured.\n"
+        ], $output);
         $this->assertEquals(1, $this->getExitCode());
     }
 
     /**
      * @test
      */
-    public function testSkippedMigrationWontRun() {
-        $this->createTestMigration('WontRun');
-        $this->initMigrations();
-
-        // Skip it
-        $this->executeMultiCommand([
+    public function testSkipWithNoMigrations() {
+        $output = $this->executeMultiCommand([
             SkipMigrationsCommand::class,
-            '--name' => 'App\\Database\\Migrations\\WontRun',
+            '--all' => '',
             '--connection' => 'test-connection'
         ]);
 
-        // Now run migrations
+        $this->assertEquals([
+            "Info: No migrations found.\n"
+        ], $output);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipWithNoModeFlag() {
+        $this->createTestMigration('NoMode1');
+        $this->initMigrations();
+
         $output = $this->executeMultiCommand([
-            RunMigrationsCommandNew::class,
+            SkipMigrationsCommand::class,
             '--connection' => 'test-connection'
         ]);
 
         $outputStr = implode('', $output);
-        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\WontRun', $outputStr);
-        $this->assertStringNotContainsString('Applied: App\\Database\\Migrations\\WontRun', $outputStr);
-        $this->assertEquals(0, $this->getExitCode());
+        $this->assertStringContainsString('Provide --name, --all, or --up-to', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
     }
 
-    // --- Helpers ---
-
-    private function initMigrations(string $env = 'dev'): void {
-        $args = [
-            InitMigrationsCommand::class,
-            '--connection' => 'test-connection'
-        ];
-
-        if ($env !== 'dev') {
-            $args['--env'] = $env;
+    private function cleanPhpFiles(string $dir): void {
+        if (!is_dir($dir)) {
+            return;
         }
 
-        $this->executeMultiCommand($args);
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isFile() && $item->getExtension() === 'php') {
+                unlink($item->getRealPath());
+            } elseif ($item->isDir() && count(scandir($item->getRealPath())) === 2) {
+                rmdir($item->getRealPath());
+            }
+        }
+    }
+
+    private function cleanupMigrations(): void {
+        $dir = APP_PATH.'Database'.DS.'Migrations';
+        $this->cleanPhpFiles($dir);
+    }
+
+    private function cleanupSeeders(): void {
+        $dir = APP_PATH.'Database'.DS.'Seeders';
+        $this->cleanPhpFiles($dir);
     }
 
     private function createTestMigration(string $name): void {
@@ -278,38 +292,10 @@ PHP;
         file_put_contents($dir.DS.$name.'.php', $content);
     }
 
-    private function cleanupMigrations(): void {
-        $dir = APP_PATH.'Database'.DS.'Migrations';
-        $this->cleanPhpFiles($dir);
-    }
-
-    private function cleanPhpFiles(string $dir): void {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
-
-        foreach ($iterator as $item) {
-            if ($item->isFile() && $item->getExtension() === 'php') {
-                unlink($item->getRealPath());
-            } elseif ($item->isDir() && count(scandir($item->getRealPath())) === 2) {
-                rmdir($item->getRealPath());
-            }
-        }
-    }
-
-    private function cleanupSeeders(): void {
-        $dir = APP_PATH.'Database'.DS.'Seeders';
-        $this->cleanPhpFiles($dir);
-    }
-
     private function dropSchemaTable(): void {
         try {
             $conn = App::getConfig()->getDBConnection('test-connection');
+
             if ($conn !== null) {
                 $db = new \WebFiori\Database\Database($conn);
                 $db->raw("DROP TABLE IF EXISTS schema_changes")->execute();
@@ -318,6 +304,21 @@ PHP;
         } catch (\Throwable $e) {
             // Ignore
         }
+    }
+
+    // --- Helpers ---
+
+    private function initMigrations(string $env = 'dev'): void {
+        $args = [
+            InitMigrationsCommand::class,
+            '--connection' => 'test-connection'
+        ];
+
+        if ($env !== 'dev') {
+            $args['--env'] = $env;
+        }
+
+        $this->executeMultiCommand($args);
     }
 
     private function setupTestConnection(): void {

--- a/tests/WebFiori/Framework/Tests/Cli/SkipMigrationsCommandTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/SkipMigrationsCommandTest.php
@@ -1,0 +1,342 @@
+<?php
+namespace WebFiori\Framework\Test\Cli;
+
+use WebFiori\Database\ConnectionInfo;
+use WebFiori\Framework\App;
+use WebFiori\Framework\Cli\CLITestCase;
+use WebFiori\Framework\Cli\Commands\SkipMigrationsCommand;
+use WebFiori\Framework\Cli\Commands\RunMigrationsCommandNew;
+use WebFiori\Framework\Cli\Commands\InitMigrationsCommand;
+
+/**
+ * Test cases for SkipMigrationsCommand.
+ */
+class SkipMigrationsCommandTest extends CLITestCase {
+    private ConnectionInfo $testConnection;
+
+    /**
+     * @test
+     */
+    public function testSkipWithNoConnections() {
+        App::getConfig()->removeAllDBConnections();
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => ''
+        ]);
+
+        $this->assertEquals([
+            "Info: No database connections configured.\n"
+        ], $output);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipWithInvalidConnection() {
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'ghost'
+        ]);
+
+        $this->assertEquals([
+            "Error: Connection 'ghost' not found.\n"
+        ], $output);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipWithNoMigrations() {
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $this->assertEquals([
+            "Info: No migrations found.\n"
+        ], $output);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipWithNoModeFlag() {
+        $this->createTestMigration('NoMode1');
+        $this->initMigrations();
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Provide --name, --all, or --up-to', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipAll() {
+        $this->createTestMigration('SkipAll1');
+        $this->createTestMigration('SkipAll2');
+        $this->initMigrations();
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\SkipAll1', $outputStr);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\SkipAll2', $outputStr);
+        $this->assertStringContainsString('Total skipped: 2', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipSingleByName() {
+        $this->createTestMigration('SkipSingle1');
+        $this->createTestMigration('SkipSingle2');
+        $this->initMigrations();
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--name' => 'App\\Database\\Migrations\\SkipSingle1',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\SkipSingle1', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipUpTo() {
+        $this->createTestMigration('UpToMig');
+        $this->initMigrations();
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--up-to' => 'UpToMig',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\UpToMig', $outputStr);
+        $this->assertStringContainsString('Total skipped:', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipAlreadyApplied() {
+        $this->createTestMigration('AlreadyDone');
+        $this->initMigrations();
+
+        // Run it first
+        $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        // Try to skip it
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--name' => 'App\\Database\\Migrations\\AlreadyDone',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Could not skip', $outputStr);
+        $this->assertStringContainsString('not found or already applied', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipAllWhenNothingPending() {
+        $this->createTestMigration('NoPending');
+        $this->initMigrations();
+
+        // Run it first
+        $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        // Skip all - nothing left
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('No pending migrations to skip', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkipSchemaTableMissing() {
+        $this->createTestMigration('NoTable');
+        // Do NOT call initMigrations()
+
+        $output = $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--all' => '',
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('schema_changes', $outputStr);
+        $this->assertStringContainsString('migrations:ini', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSkippedMigrationWontRun() {
+        $this->createTestMigration('WontRun');
+        $this->initMigrations();
+
+        // Skip it
+        $this->executeMultiCommand([
+            SkipMigrationsCommand::class,
+            '--name' => 'App\\Database\\Migrations\\WontRun',
+            '--connection' => 'test-connection'
+        ]);
+
+        // Now run migrations
+        $output = $this->executeMultiCommand([
+            RunMigrationsCommandNew::class,
+            '--connection' => 'test-connection'
+        ]);
+
+        $outputStr = implode('', $output);
+        $this->assertStringContainsString('Skipped: App\\Database\\Migrations\\WontRun', $outputStr);
+        $this->assertStringNotContainsString('Applied: App\\Database\\Migrations\\WontRun', $outputStr);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    // --- Helpers ---
+
+    private function initMigrations(string $env = 'dev'): void {
+        $args = [
+            InitMigrationsCommand::class,
+            '--connection' => 'test-connection'
+        ];
+
+        if ($env !== 'dev') {
+            $args['--env'] = $env;
+        }
+
+        $this->executeMultiCommand($args);
+    }
+
+    private function createTestMigration(string $name): void {
+        $dir = APP_PATH.'Database'.DS.'Migrations';
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = <<<PHP
+<?php
+namespace App\Database\Migrations;
+
+use WebFiori\Database\Database;
+use WebFiori\Database\Schema\AbstractMigration;
+
+class $name extends AbstractMigration {
+    public function up(Database \$db): void {
+        // Test migration
+    }
+    
+    public function down(Database \$db): void {
+        // Test rollback
+    }
+}
+PHP;
+
+        file_put_contents($dir.DS.$name.'.php', $content);
+    }
+
+    private function cleanupMigrations(): void {
+        $dir = APP_PATH.'Database'.DS.'Migrations';
+        $this->cleanPhpFiles($dir);
+    }
+
+    private function cleanPhpFiles(string $dir): void {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isFile() && $item->getExtension() === 'php') {
+                unlink($item->getRealPath());
+            } elseif ($item->isDir() && count(scandir($item->getRealPath())) === 2) {
+                rmdir($item->getRealPath());
+            }
+        }
+    }
+
+    private function cleanupSeeders(): void {
+        $dir = APP_PATH.'Database'.DS.'Seeders';
+        $this->cleanPhpFiles($dir);
+    }
+
+    private function dropSchemaTable(): void {
+        try {
+            $conn = App::getConfig()->getDBConnection('test-connection');
+            if ($conn !== null) {
+                $db = new \WebFiori\Database\Database($conn);
+                $db->raw("DROP TABLE IF EXISTS schema_changes")->execute();
+                $db->close();
+            }
+        } catch (\Throwable $e) {
+            // Ignore
+        }
+    }
+
+    private function setupTestConnection(): void {
+        $this->testConnection = new ConnectionInfo('mysql', 'root', MYSQL_ROOT_PASSWORD, 'testing_db', '127.0.0.1', 3306);
+        $this->testConnection->setName('test-connection');
+        App::getConfig()->addOrUpdateDBConnection($this->testConnection);
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->setupTestConnection();
+        $this->dropSchemaTable();
+        $this->cleanupMigrations();
+    }
+
+    protected function tearDown(): void {
+        $this->cleanupMigrations();
+        $this->cleanupSeeders();
+        $this->dropSchemaTable();
+        parent::tearDown();
+    }
+}

--- a/tests/WebFiori/Framework/Tests/Config/JsonDriverTest.php
+++ b/tests/WebFiori/Framework/Tests/Config/JsonDriverTest.php
@@ -254,7 +254,8 @@ class JsonDriverTest extends TestCase {
         $this->assertEquals('root', $account->getUsername());
         $this->assertEquals([
             'KG' => 9,
-            'OP' => 'hello'
+            'OP' => 'hello',
+            'connection-name' => 'New_Connection'
         ], $account->getExtars());
         $driver->removeAllDBConnections();
         $this->assertEquals(0, count($driver->getDBConnections()));
@@ -290,7 +291,8 @@ class JsonDriverTest extends TestCase {
         $this->assertEquals('root', $account->getUsername());
         $this->assertEquals([
             'A' => 'B',
-            'C' => 'D'
+            'C' => 'D',
+            'connection-name' => 'not_ok'
         ], $account->getExtars());
     }
     /**


### PR DESCRIPTION
# Summary
Two migration CLI features:
1. `migrations:skip` command for baselining existing databases
2. `--all-connections` flag on `migrations:run` for multi-database architectures

## Motivation
- **Baselining:** When adopting the migration system on an existing database, developers need to mark migrations as "applied" without executing them.
- **Multi-connection:** In systems with multiple databases, migrations can target specific connections. The CLI needs to support running against all connections and validating configuration.

## Changes

### migrations:skip (Closes #320)
- New `SkipMigrationsCommand` with three modes: `--name`, `--all`, `--up-to`
- Registered in `App.php`
- 11 tests

### --all-connections (Closes #326)
- Added `--all-connections` flag to `migrations:run`
- Added `validateTargetConnections()` — warns about unknown target names and default connection names
- Fixed bug in `JsonDriver::getDBConnection()` where connection name was lost
- 10 tests

## How to Test / Verify
```bash
php vendor/bin/phpunit -c tests/phpunit10.xml --testsuite "CLI Tests" --filter "SkipMigrations|ConnectionTargeted"
```
21 tests pass. Full CLI suite: 192 tests, 0 failures.

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #320
Closes #326
Depends on: WebFiori/database#149