### PR TITLE
feat: allow middleware instances in route definitions

### DIFF
--- a/WebFiori/Framework/Router/Router.php
+++ b/WebFiori/Framework/Router/Router.php
@@ -16,6 +16,7 @@ use WebFiori\Cli\Runner;
 use WebFiori\File\exceptions\FileException;
 use WebFiori\File\File;
 use WebFiori\Framework\App;
+use WebFiori\Framework\Middleware\AbstractMiddleware;
 use WebFiori\Framework\Exceptions\RoutingException;
 use WebFiori\Framework\Ui\HTTPCodeView;
 use WebFiori\Framework\Ui\StarterPage;
@@ -950,10 +951,12 @@ class Router {
         $incInSiteMap = $options[RouteOption::SITEMAP] ?? false;
 
         if (isset($options[RouteOption::MIDDLEWARE])) {
-            if (gettype($options[RouteOption::MIDDLEWARE]) == 'array') {
-                $mdArr = $options[RouteOption::MIDDLEWARE];
-            } else if (gettype($options[RouteOption::MIDDLEWARE]) == 'string') {
-                $mdArr = [$options[RouteOption::MIDDLEWARE]];
+            $raw = $options[RouteOption::MIDDLEWARE];
+
+            if (is_array($raw)) {
+                $mdArr = $raw;
+            } else if (is_string($raw) || $raw instanceof AbstractMiddleware) {
+                $mdArr = [$raw];
             } else {
                 $mdArr = [];
             }

--- a/WebFiori/Framework/Router/RouterUri.php
+++ b/WebFiori/Framework/Router/RouterUri.php
@@ -182,11 +182,19 @@ class RouterUri extends RequestUri {
     /**
      * Adds the URI to middleware or to middleware group.
      *
-     * @param string $name The name of the middleware or the group.
+     * @param string|AbstractMiddleware $middleware The name of the middleware,
+     * the group name, or a pre-configured middleware instance.
      *
      * @since 1.4
      */
-    public function addMiddleware(string $name) {
+    public function addMiddleware(string|AbstractMiddleware $middleware) {
+        if ($middleware instanceof AbstractMiddleware) {
+            MiddlewareManager::register($middleware);
+            $this->assignedMiddlewareList[] = $middleware;
+
+            return;
+        }
+        $name = $middleware;
         $mw = MiddlewareManager::getMiddleware($name);
 
         if ($mw === null) {

--- a/tests/WebFiori/Framework/Tests/Router/RouterUriTest.php
+++ b/tests/WebFiori/Framework/Tests/Router/RouterUriTest.php
@@ -447,4 +447,41 @@ class RouterUriTest extends TestCase {
         $this->expectException(\InvalidArgumentException::class);
         $uri->addMiddleware('App\\Middleware\\NonExistentMiddleware');
     }
+
+    /**
+     * @test
+     */
+    public function testAddMiddlewareByInstance() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $mw = new \TestMiddleware();
+        $uri->addMiddleware($mw);
+        $list = $uri->getMiddleware();
+        $found = false;
+
+        foreach ($list as $m) {
+            if ($m === $mw) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found);
+    }
+    /**
+     * @test
+     */
+    public function testAddMiddlewareInstanceIsRegistered() {
+        $uri = new RouterUri('https://example.com/reg', '');
+        $mw = new \TestMiddleware();
+        $uri->addMiddleware($mw);
+        $found = \WebFiori\Framework\Middleware\MiddlewareManager::getMiddleware($mw->getName());
+        $this->assertNotNull($found);
+    }
+    /**
+     * @test
+     */
+    public function testStringMiddlewareStillWorks() {
+        $uri = new RouterUri('https://example.com/str', '');
+        $uri->addMiddleware('start-session');
+        $list = $uri->getMiddleware();
+        $this->assertNotEmpty($list);
+    }
 }


### PR DESCRIPTION
# Summary
Allow pre-configured middleware instances to be passed directly in route definitions, enabling per-route middleware configuration.

## Motivation
Previously, middleware could only be assigned to routes by name (string). There was no way to pass a configured instance with specific options per route. This blocked features like per-route CORS configuration or per-route rate limits. Closes #340.

## Changes
- `RouterUri::addMiddleware()` now accepts `string|AbstractMiddleware`
- If an instance is passed, it is registered in `MiddlewareManager` and added to the route directly
- `Router` middleware option parsing accepts mixed arrays containing both strings and objects
- Added `use` import for `AbstractMiddleware` in `Router.php`

## How to Test / Verify
```php
Router::api([
    'path' => '/users',
    'route-to' => UsersService::class,
    'middleware' => [
        'web',
        new CorsMiddleware(['origins' => ['https://app.example.com']]),
    ]
]);
```
`composer test10` — 787 tests pass, same baseline failures.

## Breaking Changes and Migration Steps
None. Fully backward compatible — existing string-based middleware assignment works unchanged.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #340
Prerequisite for #341 (CORS middleware)