### PR TITLE
feat: add maintenance mode (down/up commands)

### DIFF
--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -349,6 +349,8 @@ class App {
                 $commands = [
                     '\\WebFiori\\Framework\\Cli\\Commands\\WHelpCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\VersionCommand',
+                    '\\WebFiori\\Framework\\Cli\\Commands\\DownCommand',
+                    '\\WebFiori\\Framework\\Cli\\Commands\\UpCommand',
 
                     '\\WebFiori\\Framework\\Cli\\Commands\\SchedulerCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\SchedulerRunCommand',
@@ -888,6 +890,7 @@ class App {
             Ini::get()->createIniClass('Middleware', 'Register middleware which are created outside the folder \'[APP_DIR]/Middleware\'.');
         }
         MiddlewareManager::register(new StartSessionMiddleware());
+        MiddlewareManager::register(new Middleware\CheckMaintenanceMode());
         self::call(APP_DIR.'\Ini\Middleware::initialize');
     }
     /**

--- a/WebFiori/Framework/Cli/Commands/DownCommand.php
+++ b/WebFiori/Framework/Cli/Commands/DownCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Framework\Cli\Commands;
+
+use WebFiori\Cli\Command;
+use WebFiori\Cli\Argument;
+
+/**
+ * A command to put the application in maintenance mode.
+ */
+class DownCommand extends Command {
+    public function __construct() {
+        parent::__construct('down', [
+            new Argument('--allow', 'Comma-separated IPs allowed during maintenance.', true),
+            new Argument('--retry', 'Retry-After header value in seconds.', true),
+            new Argument('--message', 'Custom maintenance message.', true),
+            new Argument('--api-prefix', 'URL prefix for API routes (used for JSON responses).', true),
+        ], 'Put the application in maintenance mode.');
+    }
+    /**
+     * Execute the command.
+     */
+    public function exec(): int {
+        $data = [
+            'time' => date('c'),
+            'allowed' => [],
+            'retry_after' => 3600,
+            'message' => 'Application is under maintenance.',
+            'api_prefix' => '/api',
+        ];
+
+        $allow = $this->getArgValue('--allow');
+
+        if ($allow !== null) {
+            $data['allowed'] = array_map('trim', explode(',', $allow));
+        }
+
+        $retry = $this->getArgValue('--retry');
+
+        if ($retry !== null) {
+            $data['retry_after'] = intval($retry);
+        }
+
+        $message = $this->getArgValue('--message');
+
+        if ($message !== null) {
+            $data['message'] = $message;
+        }
+
+        $apiPrefix = $this->getArgValue('--api-prefix');
+
+        if ($apiPrefix !== null) {
+            $data['api_prefix'] = $apiPrefix;
+        }
+
+        $path = APP_PATH.'Storage'.DIRECTORY_SEPARATOR.'.maintenance';
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+        $this->println('Application is now in maintenance mode.');
+
+        return 0;
+    }
+}

--- a/WebFiori/Framework/Cli/Commands/UpCommand.php
+++ b/WebFiori/Framework/Cli/Commands/UpCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Framework\Cli\Commands;
+
+use WebFiori\Cli\Command;
+
+/**
+ * A command to bring the application out of maintenance mode.
+ */
+class UpCommand extends Command {
+    public function __construct() {
+        parent::__construct('up', [], 'Bring the application out of maintenance mode.');
+    }
+    /**
+     * Execute the command.
+     */
+    public function exec(): int {
+        $path = APP_PATH.'Storage'.DIRECTORY_SEPARATOR.'.maintenance';
+
+        if (file_exists($path)) {
+            unlink($path);
+            $this->println('Application is now live.');
+        } else {
+            $this->println('Application is not in maintenance mode.');
+        }
+
+        return 0;
+    }
+}

--- a/WebFiori/Framework/Middleware/CheckMaintenanceMode.php
+++ b/WebFiori/Framework/Middleware/CheckMaintenanceMode.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Framework\Middleware;
+
+use WebFiori\Http\Request;
+use WebFiori\Http\Response;
+
+/**
+ * Middleware that checks if the application is in maintenance mode.
+ *
+ * If the file APP_PATH/Storage/.maintenance exists, all requests are
+ * responded to with 503 Service Unavailable unless the client IP is
+ * in the allowed list.
+ */
+class CheckMaintenanceMode extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('maintenance-check');
+        $this->setPriority(PHP_INT_MAX - 1);
+        $this->addToGroup('web');
+        $this->addToGroup('api');
+    }
+    /**
+     * Check maintenance mode before processing the request.
+     */
+    public function before(Request $request, Response $response) {
+        $file = APP_PATH.'Storage'.DIRECTORY_SEPARATOR.'.maintenance';
+
+        if (!file_exists($file)) {
+            return;
+        }
+
+        $config = json_decode(file_get_contents($file), true) ?? [];
+        $allowed = $config['allowed'] ?? [];
+
+        if (in_array($request->getClientIP(), $allowed)) {
+            return;
+        }
+
+        $message = $config['message'] ?? 'Application is under maintenance.';
+        $retryAfter = $config['retry_after'] ?? 3600;
+        $apiPrefix = $config['api_prefix'] ?? '/api';
+
+        $response->setCode(503);
+        $response->addHeader('Retry-After', $retryAfter);
+
+        $isApi = str_starts_with($request->getUri()->getPath(), $apiPrefix)
+              || $request->getHeader('accept') === 'application/json'
+              || $request->getHeader('content-type') === 'application/json';
+
+        if ($isApi) {
+            $response->addHeader('Content-Type', 'application/json');
+            $response->write(json_encode([
+                'message' => $message,
+                'retry_after' => $retryAfter,
+            ]));
+        } else {
+            $customPage = APP_PATH.'Storage'.DIRECTORY_SEPARATOR.'maintenance.html';
+
+            if (file_exists($customPage)) {
+                $response->write(file_get_contents($customPage));
+            } else {
+                $response->addHeader('Content-Type', 'text/html');
+                $response->write('<html><body><h1>Under Maintenance</h1><p>'.$message.'</p></body></html>');
+            }
+        }
+        $response->send();
+        exit;
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+}

--- a/tests/WebFiori/Framework/Tests/Cli/HelpCommandTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/HelpCommandTest.php
@@ -20,6 +20,8 @@ class HelpCommandTest extends CLITestCase {
             "    help:                    Display CLI Help. To display help for specific command, use the argument \"--command\" with this command.\n",
             "    v:                       Display framework version info.\n",
 
+            "    down:                    Put the application in maintenance mode.\n",
+            "    up:                      Bring the application out of maintenance mode.\n",
             "    scheduler:               Run tasks scheduler.\n",
             "    scheduler:run:           Run the tasks scheduler check.\n",
             "    scheduler:daemon:        Run the scheduler in a loop for a limited duration.\n",


### PR DESCRIPTION
# Summary
Add the ability to put the application in maintenance mode via CLI commands, returning 503 to all requests except allowed IPs.

## Motivation
During deployments or upgrades, there is no way to gracefully stop serving requests. This can lead to errors if the database is being migrated or code is partially deployed. Closes #351.

## Changes
- `DownCommand` (`php webfiori down`) — creates `App/Storage/.maintenance` with config
- `UpCommand` (`php webfiori up`) — removes the file
- `CheckMaintenanceMode` middleware — checks for the file on every request
  - Returns 503 with `Retry-After` header
  - JSON response for API requests (path prefix or Accept header detection)
  - HTML response for web requests (custom `maintenance.html` or default)
  - Allowed IPs bypass maintenance mode
- Middleware registered in both `web` and `api` groups at priority `PHP_INT_MAX - 1`

## How to Test / Verify
```bash
php webfiori down --allow=127.0.0.1 --message="Back in 5 min" --retry=300
# All requests get 503 except from 127.0.0.1
php webfiori up
# Application is live again
```
`composer test10` — 784 tests, same baseline failures.

## Breaking Changes and Migration Steps
None.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #351