### PR TITLE
feat: add dependency-based middleware ordering

### DIFF
--- a/WebFiori/Framework/Middleware/AbstractMiddleware.php
+++ b/WebFiori/Framework/Middleware/AbstractMiddleware.php
@@ -195,6 +195,18 @@ abstract class AbstractMiddleware implements Comparable {
      *
      * @since 1.0
      */
+    /**
+     * Returns an array of middleware names that this middleware depends on.
+     *
+     * Middleware listed here will be executed before this one. The framework
+     * performs a topological sort based on these dependencies to determine
+     * execution order.
+     *
+     * @return array An array of middleware names (strings).
+     */
+    public function getDependencies(): array {
+        return [];
+    }
     public function getPriority() : int {
         return $this->priority;
     }

--- a/WebFiori/Framework/Router/RouterUri.php
+++ b/WebFiori/Framework/Router/RouterUri.php
@@ -290,13 +290,9 @@ class RouterUri extends RequestUri {
      */
     public function getMiddleware() : array {
         if (count($this->assignedMiddlewareList) != count($this->sortedMiddleeareList)) {
-            $compareFunc = function ($a, $b) {
-                return $a->compare($b);
-            };
-            $this->sortedMiddleeareList = $this->assignedMiddlewareList;
-            
-            usort($this->sortedMiddleeareList, $compareFunc);
+            $this->sortedMiddleeareList = $this->sortByDependencies($this->assignedMiddlewareList);
         }
+
         return $this->sortedMiddleeareList;
     }
 
@@ -610,5 +606,100 @@ class RouterUri extends RequestUri {
         $requestedPath = $requestedArr['path'];
 
         return $this->comparePathHelper($originalPath, $requestedPath);
+    }
+
+    /**
+     * Sorts middleware using topological sort based on dependencies.
+     * Falls back to priority for middleware with no dependency relationship.
+     *
+     * @param array $middlewareList Array of AbstractMiddleware instances.
+     *
+     * @return array Sorted array.
+     *
+     * @throws \WebFiori\Framework\Exceptions\RoutingException If circular dependency detected.
+     */
+    private function sortByDependencies(array $middlewareList): array {
+        if (empty($middlewareList)) {
+            return [];
+        }
+
+        // Build name-to-middleware map
+        $byName = [];
+
+        foreach ($middlewareList as $mw) {
+            $byName[$mw->getName()] = $mw;
+        }
+
+        // Build adjacency list (dependency graph)
+        $graph = [];
+        $inDegree = [];
+
+        foreach ($middlewareList as $mw) {
+            $name = $mw->getName();
+
+            if (!isset($graph[$name])) {
+                $graph[$name] = [];
+            }
+
+            if (!isset($inDegree[$name])) {
+                $inDegree[$name] = 0;
+            }
+
+            foreach ($mw->getDependencies() as $dep) {
+                if (isset($byName[$dep])) {
+                    $graph[$dep][] = $name;
+
+                    if (!isset($inDegree[$dep])) {
+                        $inDegree[$dep] = 0;
+                    }
+                    $inDegree[$name]++;
+                }
+            }
+        }
+
+        // Kahn's algorithm with priority as tiebreaker
+        $queue = [];
+
+        foreach ($inDegree as $name => $degree) {
+            if ($degree === 0) {
+                $queue[] = $name;
+            }
+        }
+
+        // Sort initial queue by priority (higher first)
+        usort($queue, function ($a, $b) use ($byName) {
+            return $byName[$b]->getPriority() - $byName[$a]->getPriority();
+        });
+
+        $sorted = [];
+
+        while (!empty($queue)) {
+            $current = array_shift($queue);
+            $sorted[] = $byName[$current];
+
+            foreach ($graph[$current] as $neighbor) {
+                $inDegree[$neighbor]--;
+
+                if ($inDegree[$neighbor] === 0) {
+                    $queue[] = $neighbor;
+                }
+            }
+
+            // Re-sort queue by priority for tiebreaking
+            usort($queue, function ($a, $b) use ($byName) {
+                return $byName[$b]->getPriority() - $byName[$a]->getPriority();
+            });
+        }
+
+        if (count($sorted) !== count($middlewareList)) {
+            // Circular dependency detected — find the cycle
+            $remaining = array_diff(array_keys($inDegree), array_map(fn ($m) => $m->getName(), $sorted));
+
+            throw new \WebFiori\Framework\Exceptions\RoutingException(
+                "Circular middleware dependency detected involving: '".implode("', '", $remaining)."'"
+            );
+        }
+
+        return $sorted;
     }
 }

--- a/tests/WebFiori/Framework/Tests/Middleware/MiddlewareDependencyTest.php
+++ b/tests/WebFiori/Framework/Tests/Middleware/MiddlewareDependencyTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace WebFiori\Framework\Test\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Framework\Middleware\AbstractMiddleware;
+use WebFiori\Framework\Middleware\MiddlewareManager;
+use WebFiori\Framework\Router\RouterUri;
+use WebFiori\Http\Request;
+use WebFiori\Http\Response;
+
+class MiddlewareA extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('mw-a');
+        $this->setPriority(10);
+    }
+
+    public function getDependencies(): array {
+        return [];
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareB extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('mw-b');
+        $this->setPriority(100);
+    }
+
+    public function getDependencies(): array {
+        return ['mw-a']; // must run after A
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareC extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('mw-c');
+        $this->setPriority(50);
+    }
+
+    public function getDependencies(): array {
+        return ['mw-b']; // must run after B (which runs after A)
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareX extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('mw-x');
+        $this->setPriority(200);
+    }
+
+    public function getDependencies(): array {
+        return ['mw-y']; // circular: X depends on Y
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareY extends AbstractMiddleware {
+    public function __construct() {
+        parent::__construct('mw-y');
+        $this->setPriority(200);
+    }
+
+    public function getDependencies(): array {
+        return ['mw-x']; // circular: Y depends on X
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareDependencyTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testDependencyOrderIsRespected() {
+        $uri = new RouterUri('https://example.com/dep', '');
+        // Add in wrong priority order: B has higher priority but depends on A
+        $b = new MiddlewareB();
+        $a = new MiddlewareA();
+        MiddlewareManager::register($b);
+        MiddlewareManager::register($a);
+        $uri->addMiddleware('mw-b');
+        $uri->addMiddleware('mw-a');
+
+        $list = $uri->getMiddleware();
+        $names = array_map(fn ($m) => $m->getName(), $list);
+
+        // A must come before B regardless of priority
+        $this->assertEquals(['mw-a', 'mw-b'], $names);
+    }
+    /**
+     * @test
+     */
+    public function testChainedDependencies() {
+        $uri = new RouterUri('https://example.com/chain', '');
+        // C depends on B, B depends on A. Add in reverse.
+        MiddlewareManager::register(new MiddlewareC());
+        MiddlewareManager::register(new MiddlewareB());
+        MiddlewareManager::register(new MiddlewareA());
+        $uri->addMiddleware('mw-c');
+        $uri->addMiddleware('mw-b');
+        $uri->addMiddleware('mw-a');
+
+        $list = $uri->getMiddleware();
+        $names = array_map(fn ($m) => $m->getName(), $list);
+
+        $this->assertEquals(['mw-a', 'mw-b', 'mw-c'], $names);
+    }
+    /**
+     * @test
+     */
+    public function testPriorityUsedAsTiebreaker() {
+        $uri = new RouterUri('https://example.com/tie', '');
+        // A (priority 10) and C (priority 50) have no dependency on each other
+        // but both are independent. C should come first due to higher priority.
+        $a = new MiddlewareA(); // priority 10, no deps
+        $c = new MiddlewareC(); // priority 50, depends on mw-b
+        // Without B present, C's dependency on mw-b is unresolvable (ignored)
+        // So A and C are independent — sorted by priority
+        MiddlewareManager::register($a);
+        $uri->addMiddleware('mw-a');
+
+        // Create a standalone middleware with priority 50 and no deps
+        $standalone = new class() extends AbstractMiddleware {
+            public function __construct() {
+                parent::__construct('mw-standalone');
+                $this->setPriority(50);
+            }
+
+            public function after(Request $request, Response $response) {
+            }
+
+            public function afterSend(Request $request, Response $response) {
+            }
+
+            public function before(Request $request, Response $response) {
+            }
+        };
+        MiddlewareManager::register($standalone);
+        $uri->addMiddleware('mw-standalone');
+
+        $list = $uri->getMiddleware();
+        $names = array_map(fn ($m) => $m->getName(), $list);
+
+        // Higher priority first when no dependency relationship
+        $this->assertEquals(['mw-standalone', 'mw-a'], $names);
+    }
+    /**
+     * @test
+     */
+    public function testCircularDependencyThrows() {
+        $this->expectException(\WebFiori\Framework\Exceptions\RoutingException::class);
+        $this->expectExceptionMessage('Circular middleware dependency');
+
+        $uri = new RouterUri('https://example.com/circular', '');
+        MiddlewareManager::register(new MiddlewareX());
+        MiddlewareManager::register(new MiddlewareY());
+        $uri->addMiddleware('mw-x');
+        $uri->addMiddleware('mw-y');
+
+        $uri->getMiddleware(); // triggers sort
+    }
+    /**
+     * @test
+     */
+    public function testNoDependenciesFallsBackToPriority() {
+        $uri = new RouterUri('https://example.com/prio', '');
+        $a = new MiddlewareA(); // priority 10
+        $b = new MiddlewareB(); // priority 100, depends on A
+
+        // Only add A — no dependencies, just priority
+        $standalone50 = new class() extends AbstractMiddleware {
+            public function __construct() {
+                parent::__construct('mw-p50');
+                $this->setPriority(50);
+            }
+
+            public function after(Request $request, Response $response) {
+            }
+
+            public function afterSend(Request $request, Response $response) {
+            }
+
+            public function before(Request $request, Response $response) {
+            }
+        };
+
+        MiddlewareManager::register($a);
+        MiddlewareManager::register($standalone50);
+        $uri->addMiddleware('mw-a');
+        $uri->addMiddleware('mw-p50');
+
+        $list = $uri->getMiddleware();
+        $names = array_map(fn ($m) => $m->getName(), $list);
+
+        // p50 has higher priority, no deps → comes first
+        $this->assertEquals(['mw-p50', 'mw-a'], $names);
+    }
+    /**
+     * @test
+     */
+    public function testEmptyMiddlewareList() {
+        $uri = new RouterUri('https://example.com/empty', '');
+        $list = $uri->getMiddleware();
+        $this->assertEmpty($list);
+    }
+}


### PR DESCRIPTION
# Summary
Add a declarative dependency system for middleware ordering. Middleware can declare which other middleware must run before it, and the framework automatically resolves execution order via topological sort.

## Motivation
The priority-based ordering relies on magic numbers and implicit dependencies. Developers must know the priority of all other middleware to set theirs correctly. With dependencies, each middleware declares its own requirements — no global knowledge needed. Closes #334.

## Changes
- Add `getDependencies(): array` to `AbstractMiddleware` (default returns `[]`)
- `RouterUri::getMiddleware()` now performs topological sort (Kahn's algorithm)
- Priority is used as tiebreaker for middleware with no dependency relationship
- Circular dependencies throw `RoutingException` with the involved middleware names
- Add `sortByDependencies()` private method to `RouterUri`

## How to Test / Verify
```php
class RateLimitMiddleware extends AbstractMiddleware {
    public function getDependencies(): array {
        return ['start-session']; // needs session for key
    }
}

class CsrfMiddleware extends AbstractMiddleware {
    public function getDependencies(): array {
        return ['start-session']; // needs session for token
    }
}
```
Framework automatically ensures `start-session` runs before both, regardless of priority values.

`composer test10` — 790 tests, same baseline failures.

## Breaking Changes and Migration Steps
None. Existing middleware without `getDependencies()` returns `[]` by default and continues to sort by priority exactly as before.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #334