### PR TITLE
fix(test): resolve all baseline test failures

### DIFF
--- a/tests/WebFiori/Framework/Tests/Cli/AddDbConnectionCommandTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/AddDbConnectionCommandTest.php
@@ -31,6 +31,7 @@ class AddDbConnectionCommandTest extends CLITestCase {
             "Select database type:\n",
             "0: mysql\n",
             "1: mssql\n",
+            "2: sqlite\n",
             "Database host: Enter = '127.0.0.1'\n",
             "Port number: Enter = '3306'\n",
             "Username:\n",
@@ -70,19 +71,20 @@ class AddDbConnectionCommandTest extends CLITestCase {
         $this->assertEquals("Select database type:\n", $output[0]);
         $this->assertEquals("0: mysql\n", $output[1]);
         $this->assertEquals("1: mssql\n", $output[2]);
-        $this->assertEquals("Database host: Enter = '127.0.0.1'\n", $output[3]);
-        $this->assertEquals("Port number: Enter = '3306'\n", $output[4]);
-        $this->assertEquals("Username:\n", $output[5]);
-        $this->assertEquals("Password:\n", $output[6]);
-        $this->assertEquals("***********\n", $output[7]);
-        $this->assertEquals("Database name:\n", $output[8]);
-        $this->assertEquals("Give your connection a friendly name: Enter = '$connName'\n", $output[9]);
-        $this->assertEquals("Trying to connect to the database...\n", $output[10]);
-        $this->assertEquals("Trying with 'localhost'...\n", $output[11]);
-        $this->assertEquals("Error: Unable to connect to the database.\n", $output[12]);
-        $this->assertStringContainsString("Error: Unable to connect to database: 1045 - Access denied for user", $output[13]);
-        $this->assertEquals("Would you like to store connection information anyway?(y/N)\n", $output[14]);
-        $this->assertEquals("Success: Connection information was stored in application configuration.\n", $output[15]);
+        $this->assertEquals("2: sqlite\n", $output[3]);
+        $this->assertEquals("Database host: Enter = '127.0.0.1'\n", $output[4]);
+        $this->assertEquals("Port number: Enter = '3306'\n", $output[5]);
+        $this->assertEquals("Username:\n", $output[6]);
+        $this->assertEquals("Password:\n", $output[7]);
+        $this->assertEquals("***********\n", $output[8]);
+        $this->assertEquals("Database name:\n", $output[9]);
+        $this->assertEquals("Give your connection a friendly name: Enter = '$connName'\n", $output[10]);
+        $this->assertEquals("Trying to connect to the database...\n", $output[11]);
+        $this->assertEquals("Trying with 'localhost'...\n", $output[12]);
+        $this->assertEquals("Error: Unable to connect to the database.\n", $output[13]);
+        $this->assertStringContainsString("Error: Unable to connect to database: 1045 - Access denied for user", $output[14]);
+        $this->assertEquals("Would you like to store connection information anyway?(y/N)\n", $output[15]);
+        $this->assertEquals("Success: Connection information was stored in application configuration.\n", $output[16]);
     }
     /**
      * @test
@@ -111,18 +113,19 @@ class AddDbConnectionCommandTest extends CLITestCase {
         $this->assertEquals("Select database type:\n", $output[0]);
         $this->assertEquals("0: mysql\n", $output[1]);
         $this->assertEquals("1: mssql\n", $output[2]);
-        $this->assertEquals("Database host: Enter = '127.0.0.1'\n", $output[3]);
-        $this->assertEquals("Port number: Enter = '3306'\n", $output[4]);
-        $this->assertEquals("Username:\n", $output[5]);
-        $this->assertEquals("Password:\n", $output[6]);
-        $this->assertEquals("***********\n", $output[7]);
-        $this->assertEquals("Database name:\n", $output[8]);
-        $this->assertEquals("Give your connection a friendly name: Enter = '$connName'\n", $output[9]);
-        $this->assertEquals("Trying to connect to the database...\n", $output[10]);
-        $this->assertEquals("Trying with 'localhost'...\n", $output[11]);
-        $this->assertEquals("Error: Unable to connect to the database.\n", $output[12]);
-        $this->assertStringContainsString("Error: Unable to connect to database: 1045 - Access denied for user", $output[13]);
-        $this->assertEquals("Would you like to store connection information anyway?(y/N)\n", $output[14]);
+        $this->assertEquals("2: sqlite\n", $output[3]);
+        $this->assertEquals("Database host: Enter = '127.0.0.1'\n", $output[4]);
+        $this->assertEquals("Port number: Enter = '3306'\n", $output[5]);
+        $this->assertEquals("Username:\n", $output[6]);
+        $this->assertEquals("Password:\n", $output[7]);
+        $this->assertEquals("***********\n", $output[8]);
+        $this->assertEquals("Database name:\n", $output[9]);
+        $this->assertEquals("Give your connection a friendly name: Enter = '$connName'\n", $output[10]);
+        $this->assertEquals("Trying to connect to the database...\n", $output[11]);
+        $this->assertEquals("Trying with 'localhost'...\n", $output[12]);
+        $this->assertEquals("Error: Unable to connect to the database.\n", $output[13]);
+        $this->assertStringContainsString("Error: Unable to connect to database: 1045 - Access denied for user", $output[14]);
+        $this->assertEquals("Would you like to store connection information anyway?(y/N)\n", $output[15]);
     }
     /**
      * @test

--- a/tests/WebFiori/Framework/Tests/Cli/IntegrationAllCommandsTest.php
+++ b/tests/WebFiori/Framework/Tests/Cli/IntegrationAllCommandsTest.php
@@ -60,6 +60,7 @@ class IntegrationAllCommandsTest extends CLITestCase {
             "Select database type:\n",
             "0: mysql\n",
             "1: mssql\n",
+            "2: sqlite\n",
             "Database host: Enter = '127.0.0.1'\n",
             "Port number: Enter = '3306'\n",
             "Username:\n",

--- a/tests/WebFiori/Framework/Tests/Session/SessionsManagerTest.php
+++ b/tests/WebFiori/Framework/Tests/Session/SessionsManagerTest.php
@@ -16,6 +16,15 @@ use WebFiori\Framework\Session\SessionStatus;
  * @author Ibrahim
  */
 class SessionsManagerTest extends TestCase {
+
+    private function skipIfMssqlUnavailable(): void {
+        try {
+            $dsn = 'sqlsrv:Server='.SQL_SERVER_HOST.',1433;Database='.SQL_SERVER_DB.';TrustServerCertificate=true';
+            new \PDO($dsn, SQL_SERVER_USER, SQL_SERVER_PASS);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('MSSQL not available: '.$e->getMessage());
+        }
+    }
     /**
      * @test
      */
@@ -159,6 +168,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testDatabaseSession01() {
+        $this->skipIfMssqlUnavailable();
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage("208 - [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Invalid object name 'session_data'.");
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
@@ -174,6 +184,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testDatabaseSession02() {
+        $this->skipIfMssqlUnavailable();
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
             'TrustServerCertificate' => 'true'
         ]);
@@ -282,6 +293,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testDropDbTables00() {
+        $this->skipIfMssqlUnavailable();
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage("208 - [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Invalid object name 'session_data'.");
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
@@ -313,6 +325,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testInitSessionsDb() {
+        $this->skipIfMssqlUnavailable();
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
             'TrustServerCertificate' => 'true'
         ]);
@@ -330,6 +343,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testDbSessions00() {
+        $this->skipIfMssqlUnavailable();
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
             'TrustServerCertificate' => 'true'
         ]);
@@ -433,6 +447,7 @@ class SessionsManagerTest extends TestCase {
      * @test
      */
     public function testCloseDb00() {
+        $this->skipIfMssqlUnavailable();
         $conn = new ConnectionInfo('mssql', SQL_SERVER_USER, SQL_SERVER_PASS, SQL_SERVER_DB, SQL_SERVER_HOST, 1433, [
             'TrustServerCertificate' => 'true'
         ]);


### PR DESCRIPTION
# Summary
Fix all pre-existing test failures so the test suite passes cleanly (0 errors, 0 failures).

## Motivation
The test suite had 4 errors and 6 failures that were unrelated to any recent changes. These masked real regressions and made CI unreliable.

## Changes
- **MSSQL session tests:** Add `skipIfMssqlUnavailable()` helper that marks tests as skipped when MSSQL container is unreachable (same pattern as `MSSQLSessionStorageTest`)
- **AddDbConnectionCommandTest:** Update expected CLI output to include `"2: sqlite\n"` (added by database v2.2 upgrade)
- **IntegrationAllCommandsTest:** Same sqlite output fix
- **Fix shifted array indices** in test01/test04 that were incorrectly offset

## How to Test / Verify
`composer test10` — **784 tests, 0 errors, 0 failures**, 20 skipped (MSSQL tests when container unavailable).

## Breaking Changes and Migration Steps
None.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Not Applicable