### PR TITLE
refactor: expose TasksManager setInstance/resetInstance

### DIFF
--- a/WebFiori/Framework/Scheduler/TasksManager.php
+++ b/WebFiori/Framework/Scheduler/TasksManager.php
@@ -280,6 +280,20 @@ class TasksManager {
         return self::$tasksManager;
     }
     /**
+     * Replaces the default TasksManager instance.
+     *
+     * @param TasksManager $manager The instance to use.
+     */
+    public static function setInstance(TasksManager $manager): void {
+        self::$tasksManager = $manager;
+    }
+    /**
+     * Destroys the default instance. Next call to get() creates a fresh one.
+     */
+    public static function resetInstance(): void {
+        self::$tasksManager = null;
+    }
+    /**
      * Returns the number of current hour in the day as integer.
      *
      * This method is used by the class 'AbstractTask' to validate task


### PR DESCRIPTION
# Summary
Make the TasksManager instance swappable for testing and DI container integration.

## Motivation
TasksManager had no way to swap or reset its singleton instance. Closes #344.

## Changes
- `TasksManager::setInstance(TasksManager $manager)` — new
- `TasksManager::resetInstance()` — new
- `TasksManager::get()` was already public — unchanged

## How to Test / Verify
`composer test10` — 772 tests pass.

## Breaking Changes and Migration Steps
None.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #344
Prerequisite for #345 (service container)