### PR TITLE
test: add tests for new features (HealthCheck, MiddlewareRegistry, Container)

### DIFF
--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -167,6 +167,7 @@ class App {
         $this->initRoutes();
         $this->initHealthCheck();
         $this->initScheduler();
+        $this->initContainer();
         self::getResponse()->beforeSend(function ()
         {
             register_shutdown_function(function()
@@ -280,6 +281,14 @@ class App {
      */
     public static function getResponse() : Response {
         return self::$Response;
+    }
+    /**
+     * Returns the application DI container.
+     *
+     * @return \WebFiori\Container\Container
+     */
+    public static function container(): \WebFiori\Container\Container {
+        return \WebFiori\Container\ContainerFacade::getInstance();
     }
     /**
      * Returns the application logger instance.
@@ -579,6 +588,13 @@ class App {
                 }
             }
         });
+    }
+    private function initContainer() {
+        $container = \WebFiori\Container\ContainerFacade::getInstance();
+        $container->instance(\WebFiori\Framework\Session\SessionManager::class, \WebFiori\Framework\Session\SessionsManager::getInstance());
+        $container->instance(\WebFiori\Framework\Middleware\MiddlewareRegistry::class, \WebFiori\Framework\Middleware\MiddlewareManager::getInstance());
+        $container->instance(\WebFiori\Framework\Router\Router::class, \WebFiori\Framework\Router\Router::getInstance());
+        $container->instance(\WebFiori\Framework\Scheduler\TasksManager::class, \WebFiori\Framework\Scheduler\TasksManager::get());
     }
     private function initMiddleware() {
         App::autoRegister('Middleware', function(AbstractMiddleware $inst)

--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -35,6 +35,16 @@ use WebFiori\Framework\Router\RouterUri;
 use WebFiori\Framework\Scheduler\TasksManager;
 use WebFiori\Http\Request;
 use WebFiori\Http\Response;
+use WebFiori\Container\Container;
+use WebFiori\Container\ContainerFacade;
+use WebFiori\Event\EventDispatcherFacade;
+use WebFiori\Log\FileLogger;
+use WebFiori\Log\Logger;
+use WebFiori\Log\LoggerFacade;
+use WebFiori\Log\LogLevel;
+use WebFiori\Queue\FileQueueStorage;
+use WebFiori\Queue\Queue;
+use WebFiori\Queue\QueueFacade;
 /**
  * The time at which the framework was booted in microseconds as a float.
  *
@@ -125,13 +135,13 @@ class App {
     private function __construct() {
         // Initialize logger
         $logDir = APP_PATH.'Storage'.DS.'Logs';
-        $minLevel = (defined('WF_VERBOSE') && WF_VERBOSE === true) ? \WebFiori\Log\LogLevel::DEBUG : \WebFiori\Log\LogLevel::WARNING;
-        \WebFiori\Log\LoggerFacade::setInstance(new \WebFiori\Log\FileLogger($logDir, $minLevel));
+        $minLevel = (defined('WF_VERBOSE') && WF_VERBOSE === true) ? LogLevel::DEBUG : LogLevel::WARNING;
+        LoggerFacade::setInstance(new FileLogger($logDir, $minLevel));
 
         // Initialize queue storage
         $queueDir = APP_PATH.'Storage'.DS.'Queue';
-        \WebFiori\Queue\QueueFacade::setInstance(
-            new \WebFiori\Queue\Queue(new \WebFiori\Queue\FileQueueStorage($queueDir))
+        QueueFacade::setInstance(
+            new Queue(new FileQueueStorage($queueDir))
         );
         $this->checkAppDir();
         $this->setHandlers();
@@ -285,18 +295,18 @@ class App {
     /**
      * Returns the application DI container.
      *
-     * @return \WebFiori\Container\Container
+     * @return Container
      */
-    public static function container(): \WebFiori\Container\Container {
-        return \WebFiori\Container\ContainerFacade::getInstance();
+    public static function container(): Container {
+        return ContainerFacade::getInstance();
     }
     /**
      * Returns the application logger instance.
      *
-     * @return \WebFiori\Log\Logger
+     * @return Logger
      */
-    public static function log(): \WebFiori\Log\Logger {
-        return \WebFiori\Log\LoggerFacade::getInstance();
+    public static function log(): Logger {
+        return LoggerFacade::getInstance();
     }
     /**
      * Returns an instance which represents the class that is used to run the
@@ -408,11 +418,11 @@ class App {
                 App::getRunner()->start();
             } else {
                 //route user request.
-                \WebFiori\Event\EventDispatcherFacade::dispatch(new Events\RequestReceived(self::getRequest()));
+                EventDispatcherFacade::dispatch(new Events\RequestReceived(self::getRequest()));
                 Router::route(self::getRequest()->getRequestedURI());
                 self::getResponse()->send();
                 $duration = (microtime(true) - MICRO_START) * 1000;
-                \WebFiori\Event\EventDispatcherFacade::dispatch(new Events\ResponseSent(self::getRequest(), self::getResponse(), $duration));
+                EventDispatcherFacade::dispatch(new Events\ResponseSent(self::getRequest(), self::getResponse(), $duration));
             }
         }
     }
@@ -583,14 +593,14 @@ class App {
                     $eventClass = $params[0]->getType()->getName();
 
                     if ($eventClass !== 'object') {
-                        \WebFiori\Event\EventDispatcherFacade::listen($eventClass, $instance);
+                        EventDispatcherFacade::listen($eventClass, $instance);
                     }
                 }
             }
         });
     }
     private function initContainer() {
-        $container = \WebFiori\Container\ContainerFacade::getInstance();
+        $container = ContainerFacade::getInstance();
         $container->instance(\WebFiori\Framework\Session\SessionManager::class, \WebFiori\Framework\Session\SessionsManager::getInstance());
         $container->instance(\WebFiori\Framework\Middleware\MiddlewareRegistry::class, \WebFiori\Framework\Middleware\MiddlewareManager::getInstance());
         $container->instance(\WebFiori\Framework\Router\Router::class, \WebFiori\Framework\Router\Router::getInstance());

--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -11,9 +11,7 @@
  */
 namespace WebFiori\Framework;
 
-use Error;
 use Exception;
-use ReflectionClass;
 use WebFiori\Cli\Runner;
 use WebFiori\Error\Config\HandlerConfig;
 use WebFiori\Error\Handler;
@@ -35,6 +33,7 @@ use WebFiori\Framework\Router\RouterUri;
 use WebFiori\Framework\Scheduler\TasksManager;
 use WebFiori\Http\Request;
 use WebFiori\Http\Response;
+use ReflectionMethod;
 use WebFiori\Cache\CacheFacade;
 use WebFiori\Container\Container;
 use WebFiori\Container\ContainerFacade;
@@ -79,13 +78,6 @@ class App {
      *
      */
     const STATUS_NONE = 'NONE';
-    /**
-     * An instance of autoloader class.
-     *
-     * @var ClassLoader
-     *
-     * @since 1.0
-     */
     /**
      * A mutex lock to disallow class access during initialization state.
      *
@@ -581,7 +573,7 @@ class App {
         // Auto-discover listeners from App/Listeners/
         self::autoRegister('Listeners', function ($instance) {
             if (method_exists($instance, 'handle')) {
-                $ref = new \ReflectionMethod($instance, 'handle');
+                $ref = new ReflectionMethod($instance, 'handle');
                 $params = $ref->getParameters();
 
                 if (count($params) > 0 && $params[0]->getType() !== null) {

--- a/WebFiori/Framework/App.php
+++ b/WebFiori/Framework/App.php
@@ -35,6 +35,7 @@ use WebFiori\Framework\Router\RouterUri;
 use WebFiori\Framework\Scheduler\TasksManager;
 use WebFiori\Http\Request;
 use WebFiori\Http\Response;
+use WebFiori\Cache\CacheFacade;
 use WebFiori\Container\Container;
 use WebFiori\Container\ContainerFacade;
 use WebFiori\Event\EventDispatcherFacade;
@@ -356,7 +357,6 @@ class App {
                     '\\WebFiori\\Framework\\Cli\\Commands\\QueueStatusCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\QueueRetryCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\QueueWorkCommand',
-
                     '\\WebFiori\\Framework\\Cli\\Commands\\SchedulerCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\SchedulerRunCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\SchedulerDaemonCommand',
@@ -373,11 +373,6 @@ class App {
                     '\\WebFiori\\Framework\\Cli\\Commands\\CreateResourceCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\CreateMigrationCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\CreateSeederCommand',
-
-
-
-
-
                     '\\WebFiori\\Framework\\Cli\\Commands\\RunMigrationsCommandNew',
                     '\\WebFiori\\Framework\\Cli\\Commands\\RollbackMigrationsCommand',
                     '\\WebFiori\\Framework\\Cli\\Commands\\InitMigrationsCommand',
@@ -601,10 +596,10 @@ class App {
     }
     private function initContainer() {
         $container = ContainerFacade::getInstance();
-        $container->instance(\WebFiori\Framework\Session\SessionManager::class, \WebFiori\Framework\Session\SessionsManager::getInstance());
-        $container->instance(\WebFiori\Framework\Middleware\MiddlewareRegistry::class, \WebFiori\Framework\Middleware\MiddlewareManager::getInstance());
-        $container->instance(\WebFiori\Framework\Router\Router::class, \WebFiori\Framework\Router\Router::getInstance());
-        $container->instance(\WebFiori\Framework\Scheduler\TasksManager::class, \WebFiori\Framework\Scheduler\TasksManager::get());
+        $container->instance(Session\SessionManager::class, Session\SessionsManager::getInstance());
+        $container->instance(Middleware\MiddlewareRegistry::class, MiddlewareManager::getInstance());
+        $container->instance(Router::class, Router::getInstance());
+        $container->instance(TasksManager::class, TasksManager::get());
     }
     private function initMiddleware() {
         App::autoRegister('Middleware', function(AbstractMiddleware $inst)
@@ -626,7 +621,7 @@ class App {
         // Register built-in checks
         Health\HealthCheck::register(new Health\Checks\StorageCheck());
 
-        if (\WebFiori\Cache\CacheFacade::isEnabled()) {
+        if (CacheFacade::isEnabled()) {
             Health\HealthCheck::register(new Health\Checks\CacheCheck());
         }
 

--- a/WebFiori/Framework/Middleware/MiddlewareRegistry.php
+++ b/WebFiori/Framework/Middleware/MiddlewareRegistry.php
@@ -11,7 +11,6 @@
  */
 namespace WebFiori\Framework\Middleware;
 
-use Exception;
 
 /**
  * Concrete class that holds registered middleware and groups.
@@ -71,7 +70,7 @@ class MiddlewareRegistry {
         if (gettype($middleware) == 'string') {
             try {
                 $middleware = new $middleware();
-            } catch (Exception $exc) {
+            } catch (\Throwable $exc) {
                 return false;
             }
         }

--- a/WebFiori/Framework/Router/RouterUri.php
+++ b/WebFiori/Framework/Router/RouterUri.php
@@ -13,6 +13,7 @@ namespace WebFiori\Framework\Router;
 use Closure;
 use InvalidArgumentException;
 use WebFiori\Framework\Middleware\AbstractMiddleware;
+use WebFiori\Framework\Exceptions\RoutingException;
 use WebFiori\Framework\Middleware\MiddlewareManager;
 use WebFiori\Http\RequestUri;
 use WebFiori\Http\Uri;
@@ -624,7 +625,7 @@ class RouterUri extends RequestUri {
      *
      * @return array Sorted array.
      *
-     * @throws \WebFiori\Framework\Exceptions\RoutingException If circular dependency detected.
+     * @throws RoutingException If circular dependency detected.
      */
     private function sortByDependencies(array $middlewareList): array {
         if (empty($middlewareList)) {
@@ -711,7 +712,7 @@ class RouterUri extends RequestUri {
             // Circular dependency detected — find the cycle
             $remaining = array_diff(array_keys($inDegree), array_map(fn ($m) => $m->getName(), $sorted));
 
-            throw new \WebFiori\Framework\Exceptions\RoutingException(
+            throw new RoutingException(
                 "Circular middleware dependency detected involving: '".implode("', '", $remaining)."'"
             );
         }

--- a/WebFiori/Framework/Ui/StarterPage.php
+++ b/WebFiori/Framework/Ui/StarterPage.php
@@ -10,6 +10,8 @@
  */
 namespace WebFiori\Framework\Ui;
 
+use WebFiori\Ui\HTMLNode;
+
 class StarterPage extends WebPage {
     public function __construct() {
         parent::__construct();
@@ -415,7 +417,7 @@ background: transparent !important
         ])->text($desc);
     }
 
-    private function createCard($link, $icon, $cardTitle, $paragraph, \WebFiori\Ui\HTMLNode $el) {
+    private function createCard($link, $icon, $cardTitle, $paragraph, HTMLNode $el) {
         $card = $el->addChild('v-card', [
             'hover',
             'link',

--- a/tests/WebFiori/Framework/Tests/ContainerIntegrationTest.php
+++ b/tests/WebFiori/Framework/Tests/ContainerIntegrationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WebFiori\Framework\Test;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Container\Container;
+use WebFiori\Framework\App;
+use WebFiori\Framework\Middleware\MiddlewareRegistry;
+use WebFiori\Framework\Router\Router;
+use WebFiori\Framework\Scheduler\TasksManager;
+use WebFiori\Framework\Session\SessionManager;
+
+class ContainerIntegrationTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testContainerReturnsInstance() {
+        $container = App::container();
+        $this->assertInstanceOf(Container::class, $container);
+    }
+    /**
+     * @test
+     */
+    public function testSessionManagerRegistered() {
+        $manager = App::container()->make(SessionManager::class);
+        $this->assertInstanceOf(SessionManager::class, $manager);
+    }
+    /**
+     * @test
+     */
+    public function testMiddlewareRegistryRegistered() {
+        $registry = App::container()->make(MiddlewareRegistry::class);
+        $this->assertInstanceOf(MiddlewareRegistry::class, $registry);
+    }
+    /**
+     * @test
+     */
+    public function testRouterRegistered() {
+        $router = App::container()->make(Router::class);
+        $this->assertInstanceOf(Router::class, $router);
+    }
+    /**
+     * @test
+     */
+    public function testTasksManagerRegistered() {
+        $tasks = App::container()->make(TasksManager::class);
+        $this->assertInstanceOf(TasksManager::class, $tasks);
+    }
+    /**
+     * @test
+     */
+    public function testCustomBinding() {
+        App::container()->bind('test-key', function () {
+            return new \stdClass();
+        });
+        $obj = App::container()->make('test-key');
+        $this->assertInstanceOf(\stdClass::class, $obj);
+    }
+}

--- a/tests/WebFiori/Framework/Tests/Health/HealthCheckTest.php
+++ b/tests/WebFiori/Framework/Tests/Health/HealthCheckTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace WebFiori\Framework\Test\Health;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Framework\Health\HealthCheck;
+use WebFiori\Framework\Health\HealthCheckInterface;
+use WebFiori\Framework\Health\HealthCheckResult;
+
+class PassingCheck implements HealthCheckInterface {
+    public function getName(): string {
+        return 'passing';
+    }
+
+    public function check(): HealthCheckResult {
+        return HealthCheckResult::ok(['latency_ms' => 5]);
+    }
+}
+
+class FailingCheck implements HealthCheckInterface {
+    public function getName(): string {
+        return 'failing';
+    }
+
+    public function check(): HealthCheckResult {
+        return HealthCheckResult::fail('Connection refused');
+    }
+}
+
+class HealthCheckTest extends TestCase {
+    protected function setUp(): void {
+        HealthCheck::reset();
+    }
+    /**
+     * @test
+     */
+    public function testRunAllWithNoChecks() {
+        $result = HealthCheck::runAll();
+        $this->assertEquals('ok', $result['status']);
+        $this->assertArrayHasKey('timestamp', $result);
+        $this->assertEmpty($result['checks']);
+    }
+    /**
+     * @test
+     */
+    public function testRegisterClassBased() {
+        HealthCheck::register(new PassingCheck());
+        $this->assertEquals(1, HealthCheck::getCheckCount());
+    }
+    /**
+     * @test
+     */
+    public function testRegisterCallable() {
+        HealthCheck::register('disk', function () {
+            return ['status' => 'ok', 'free_gb' => 50];
+        });
+        $this->assertEquals(1, HealthCheck::getCheckCount());
+    }
+    /**
+     * @test
+     */
+    public function testAllPassingReturnsOk() {
+        HealthCheck::register(new PassingCheck());
+        HealthCheck::register('custom', function () {
+            return ['status' => 'ok'];
+        });
+
+        $result = HealthCheck::runAll();
+        $this->assertEquals('ok', $result['status']);
+        $this->assertCount(2, $result['checks']);
+        $this->assertEquals('ok', $result['checks']['passing']['status']);
+    }
+    /**
+     * @test
+     */
+    public function testFailingCheckReturnsFail() {
+        HealthCheck::register(new PassingCheck());
+        HealthCheck::register(new FailingCheck());
+
+        $result = HealthCheck::runAll();
+        $this->assertEquals('fail', $result['status']);
+        $this->assertEquals('ok', $result['checks']['passing']['status']);
+        $this->assertEquals('fail', $result['checks']['failing']['status']);
+        $this->assertEquals('Connection refused', $result['checks']['failing']['reason']);
+    }
+    /**
+     * @test
+     */
+    public function testCallableReturningResult() {
+        HealthCheck::register('result-check', function () {
+            return HealthCheckResult::ok(['version' => '2.0']);
+        });
+
+        $result = HealthCheck::runAll();
+        $this->assertEquals('ok', $result['checks']['result-check']['status']);
+        $this->assertEquals('2.0', $result['checks']['result-check']['version']);
+    }
+    /**
+     * @test
+     */
+    public function testReset() {
+        HealthCheck::register(new PassingCheck());
+        HealthCheck::reset();
+        $this->assertEquals(0, HealthCheck::getCheckCount());
+    }
+    /**
+     * @test
+     */
+    public function testResultOk() {
+        $r = HealthCheckResult::ok(['latency' => 10]);
+        $this->assertEquals('ok', $r->getStatus());
+        $this->assertNull($r->getReason());
+        $this->assertEquals(['latency' => 10], $r->getMeta());
+    }
+    /**
+     * @test
+     */
+    public function testResultFail() {
+        $r = HealthCheckResult::fail('timeout', ['ms' => 5000]);
+        $this->assertEquals('fail', $r->getStatus());
+        $this->assertEquals('timeout', $r->getReason());
+        $this->assertEquals(['ms' => 5000], $r->getMeta());
+    }
+    /**
+     * @test
+     */
+    public function testResultToArray() {
+        $r = HealthCheckResult::fail('down');
+        $arr = $r->toArray();
+        $this->assertEquals('fail', $arr['status']);
+        $this->assertEquals('down', $arr['reason']);
+    }
+}

--- a/tests/WebFiori/Framework/Tests/Middleware/MiddlewareRegistryTest.php
+++ b/tests/WebFiori/Framework/Tests/Middleware/MiddlewareRegistryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace WebFiori\Framework\Test\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Framework\Middleware\MiddlewareRegistry;
+use WebFiori\Framework\Middleware\AbstractMiddleware;
+use WebFiori\Http\Request;
+use WebFiori\Http\Response;
+
+class DummyMiddleware extends AbstractMiddleware {
+    public function __construct(string $name = 'dummy') {
+        parent::__construct($name);
+    }
+
+    public function after(Request $request, Response $response) {
+    }
+
+    public function afterSend(Request $request, Response $response) {
+    }
+
+    public function before(Request $request, Response $response) {
+    }
+}
+
+class MiddlewareRegistryTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testRegisterAndGet() {
+        $registry = new MiddlewareRegistry();
+        $mw = new DummyMiddleware('test-mw');
+        $registry->register($mw);
+
+        $found = $registry->getMiddleware('test-mw');
+        $this->assertSame($mw, $found);
+    }
+    /**
+     * @test
+     */
+    public function testGetMiddlewareNotFound() {
+        $registry = new MiddlewareRegistry();
+        $this->assertNull($registry->getMiddleware('nonexistent'));
+    }
+    /**
+     * @test
+     */
+    public function testRegisterByClassName() {
+        $registry = new MiddlewareRegistry();
+        $result = $registry->register(DummyMiddleware::class);
+        $this->assertTrue($result);
+        $this->assertNotNull($registry->getMiddleware('dummy'));
+    }
+    /**
+     * @test
+     */
+    public function testRegisterInvalidReturnsFalse() {
+        $registry = new MiddlewareRegistry();
+        $result = $registry->register('NonExistentClass');
+        $this->assertFalse($result);
+    }
+    /**
+     * @test
+     */
+    public function testGetGroup() {
+        $registry = new MiddlewareRegistry();
+        $mw1 = new DummyMiddleware('mw1');
+        $mw1->addToGroup('api');
+        $mw2 = new DummyMiddleware('mw2');
+        $mw2->addToGroup('api');
+        $mw3 = new DummyMiddleware('mw3');
+        $mw3->addToGroup('web');
+
+        $registry->register($mw1);
+        $registry->register($mw2);
+        $registry->register($mw3);
+
+        $apiGroup = $registry->getGroup('api');
+        $this->assertCount(2, $apiGroup);
+
+        $webGroup = $registry->getGroup('web');
+        $this->assertCount(1, $webGroup);
+
+        $emptyGroup = $registry->getGroup('nonexistent');
+        $this->assertEmpty($emptyGroup);
+    }
+    /**
+     * @test
+     */
+    public function testRemove() {
+        $registry = new MiddlewareRegistry();
+        $registry->register(new DummyMiddleware('to-remove'));
+        $registry->remove('to-remove');
+        $this->assertNull($registry->getMiddleware('to-remove'));
+    }
+    /**
+     * @test
+     */
+    public function testReset() {
+        $registry = new MiddlewareRegistry();
+        $registry->register(new DummyMiddleware('a'));
+        $registry->register(new DummyMiddleware('b'));
+        $registry->reset();
+        $this->assertEmpty($registry->getAll());
+    }
+    /**
+     * @test
+     */
+    public function testGetAll() {
+        $registry = new MiddlewareRegistry();
+        $registry->register(new DummyMiddleware('x'));
+        $registry->register(new DummyMiddleware('y'));
+        $this->assertCount(2, $registry->getAll());
+    }
+}


### PR DESCRIPTION
# Summary
Add unit and integration tests for features implemented in this release cycle.

## Changes
- **HealthCheckTest** (10 tests): registry, runAll, pass/fail checks, callable checks, reset, result value object
- **MiddlewareRegistryTest** (8 tests): register by instance/class, getMiddleware, getGroup, remove, reset, getAll, invalid class
- **ContainerIntegrationTest** (6 tests): App::container() returns instance, framework services registered (SessionManager, MiddlewareRegistry, Router, TasksManager), custom binding
- Fix `MiddlewareRegistry` to catch `\Throwable` instead of `Exception` (PHP 8 throws `Error` for missing classes)
- Add `App::container()` and `initContainer()` to dev branch

## How to Test / Verify
`composer test10` — **796 tests, 0 errors, 0 failures**, 20 skipped.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The title of the pull request follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I considered backward compatibility

## Related issues
Covers testing for #339, #343, #345