### PR TITLE
feat(middleware): auto-resolve transitive dependencies

### DIFF
--- a/WebFiori/Framework/Router/RouterUri.php
+++ b/WebFiori/Framework/Router/RouterUri.php
@@ -299,7 +299,8 @@ class RouterUri extends RequestUri {
      */
     public function getMiddleware() : array {
         if (count($this->assignedMiddlewareList) != count($this->sortedMiddleeareList)) {
-            $this->sortedMiddleeareList = $this->sortByDependencies($this->assignedMiddlewareList);
+            $resolved = $this->resolveDependencies($this->assignedMiddlewareList);
+            $this->sortedMiddleeareList = $this->sortByDependencies($resolved);
         }
 
         return $this->sortedMiddleeareList;
@@ -624,6 +625,43 @@ class RouterUri extends RequestUri {
      * @param array $middlewareList Array of AbstractMiddleware instances.
      *
      * @return array Sorted array.
+    /**
+     * Resolves transitive dependencies by pulling missing middleware from the registry.
+     *
+     * @param array $middlewareList The initially assigned middleware.
+     *
+     * @return array The expanded list including all transitive dependencies.
+     */
+    private function resolveDependencies(array $middlewareList): array {
+        $byName = [];
+
+        foreach ($middlewareList as $mw) {
+            $byName[$mw->getName()] = $mw;
+        }
+
+        $queue = $middlewareList;
+
+        while (!empty($queue)) {
+            $current = array_shift($queue);
+
+            foreach ($current->getDependencies() as $depName) {
+                if (isset($byName[$depName])) {
+                    continue;
+                }
+
+                $dep = MiddlewareManager::getMiddleware($depName);
+
+                if ($dep !== null) {
+                    $byName[$depName] = $dep;
+                    $queue[] = $dep;
+                }
+            }
+        }
+
+        return array_values($byName);
+    }
+    /**
+     * Sorts middleware using topological sort (Kahn's algorithm).
      *
      * @throws RoutingException If circular dependency detected.
      */

--- a/tests/WebFiori/Framework/Tests/Middleware/MiddlewareTransitiveDepsTest.php
+++ b/tests/WebFiori/Framework/Tests/Middleware/MiddlewareTransitiveDepsTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026-present WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Framework\Test\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Framework\Middleware\AbstractMiddleware;
+use WebFiori\Framework\Middleware\MiddlewareManager;
+use WebFiori\Framework\Router\RouterUri;
+use WebFiori\Http\Request;
+use WebFiori\Http\Response;
+
+class MwA extends AbstractMiddleware {
+    public function __construct() { parent::__construct('mw-a'); }
+    public function before(Request $r, Response $res) {}
+    public function after(Request $r, Response $res) {}
+    public function afterSend(Request $r, Response $res) {}
+}
+
+class MwB extends AbstractMiddleware {
+    public function __construct() { parent::__construct('mw-b'); }
+    public function getDependencies(): array { return ['mw-a']; }
+    public function before(Request $r, Response $res) {}
+    public function after(Request $r, Response $res) {}
+    public function afterSend(Request $r, Response $res) {}
+}
+
+class MwC extends AbstractMiddleware {
+    public function __construct() { parent::__construct('mw-c'); }
+    public function getDependencies(): array { return ['mw-b']; }
+    public function before(Request $r, Response $res) {}
+    public function after(Request $r, Response $res) {}
+    public function afterSend(Request $r, Response $res) {}
+}
+
+class MwOrphan extends AbstractMiddleware {
+    public function __construct() { parent::__construct('mw-orphan'); }
+    public function getDependencies(): array { return ['mw-nonexistent']; }
+    public function before(Request $r, Response $res) {}
+    public function after(Request $r, Response $res) {}
+    public function afterSend(Request $r, Response $res) {}
+}
+
+class MiddlewareTransitiveDepsTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        MiddlewareManager::register(new MwA());
+        MiddlewareManager::register(new MwB());
+        MiddlewareManager::register(new MwC());
+    }
+
+    protected function tearDown(): void {
+        MiddlewareManager::reset();
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function testSingleDependencyAutoResolved() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwB()); // depends on mw-a
+
+        $middleware = $uri->getMiddleware();
+        $names = array_map(fn($mw) => $mw->getName(), $middleware);
+
+        $this->assertContains('mw-a', $names);
+        $this->assertContains('mw-b', $names);
+        $this->assertCount(2, $middleware);
+    }
+
+    /** @test */
+    public function testTransitiveChainResolved() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwC()); // C depends on B, B depends on A
+
+        $middleware = $uri->getMiddleware();
+        $names = array_map(fn($mw) => $mw->getName(), $middleware);
+
+        $this->assertContains('mw-a', $names);
+        $this->assertContains('mw-b', $names);
+        $this->assertContains('mw-c', $names);
+        $this->assertCount(3, $middleware);
+    }
+
+    /** @test */
+    public function testExecutionOrderCorrect() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwC());
+
+        $middleware = $uri->getMiddleware();
+        $names = array_map(fn($mw) => $mw->getName(), $middleware);
+
+        // A must come before B, B before C
+        $this->assertLessThan(
+            array_search('mw-b', $names),
+            array_search('mw-a', $names)
+        );
+        $this->assertLessThan(
+            array_search('mw-c', $names),
+            array_search('mw-b', $names)
+        );
+    }
+
+    /** @test */
+    public function testNoDuplicateWhenDependencyAlreadyAssigned() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwA());
+        $uri->addMiddleware(new MwB());
+
+        $middleware = $uri->getMiddleware();
+        $names = array_map(fn($mw) => $mw->getName(), $middleware);
+
+        $this->assertCount(2, $middleware);
+        $this->assertEquals(1, count(array_keys($names, 'mw-a')));
+    }
+
+    /** @test */
+    public function testMissingDependencySkippedSilently() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwOrphan()); // depends on mw-nonexistent
+
+        $middleware = $uri->getMiddleware();
+        $names = array_map(fn($mw) => $mw->getName(), $middleware);
+
+        $this->assertContains('mw-orphan', $names);
+        $this->assertNotContains('mw-nonexistent', $names);
+        $this->assertCount(1, $middleware);
+    }
+
+    /** @test */
+    public function testNoDependenciesUnchanged() {
+        $uri = new RouterUri('https://example.com/test', '');
+        $uri->addMiddleware(new MwA()); // no dependencies
+
+        $middleware = $uri->getMiddleware();
+        $this->assertCount(1, $middleware);
+        $this->assertEquals('mw-a', $middleware[0]->getName());
+    }
+}


### PR DESCRIPTION
# Summary
Auto-resolve transitive middleware dependencies from the registry when assigned to a route.

## Motivation
Previously, `getDependencies()` only affected sort order for middleware already assigned. If a dependency was not explicitly listed on the route, it was silently skipped. Now assigning middleware E (which depends on D→C→B→A) auto-includes the entire chain.

## Changes
- Added `resolveDependencies()` in `RouterUri` — BFS traversal of dependency graph
- Called before `sortByDependencies()` in `getMiddleware()`
- Missing dependencies silently skipped (same as before)
- No duplicates when already assigned

## How to Test / Verify
6 unit tests covering all branches:
```
vendor/bin/phpunit --filter MiddlewareTransitiveDepsTest
```

## Breaking Changes and Migration Steps
None. Existing routes with all middleware explicitly assigned behave identically. Routes that relied on dependencies being silently skipped will now have those dependencies execute — this is the correct behavior per ADR-0002.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [ ] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [x] I ran lint/cs-fixer (if applicable)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #380